### PR TITLE
Rename timber_from_directions to create_timber

### DIFF
--- a/docs/agent_usage_instructions.md
+++ b/docs/agent_usage_instructions.md
@@ -83,7 +83,7 @@ Timbers for a typical structure are usually defined
     - `join_face_aligned_on_face_aligned_timbers` for connecting timbers at right angles
     - `join_timbers` for simple connections between two timbers
     - `create_axis_aligned_timber` for timbers aligned to cartesian axis
-    - `timber_from_directions` for arbitrarily aligned timbers
+    - `create_timber` for arbitrarily aligned timbers
 
 ## Cutting Joints
 

--- a/garbage/ladder_example.py
+++ b/garbage/ladder_example.py
@@ -54,7 +54,7 @@ def _create_side_rails(origin: V3, x_offset: Numeric, side_label: str) -> tuple[
     # Width points out of the side-frame plane (X), keeping members plane-aligned in YZ.
     width_direction = create_v3(1, 0, 0)
 
-    front_rail = timber_from_directions(
+    front_rail = create_timber(
         length=ladder_height,
         size=rail_size,
         bottom_position=front_bottom_global,
@@ -63,7 +63,7 @@ def _create_side_rails(origin: V3, x_offset: Numeric, side_label: str) -> tuple[
         ticket=f"Ladder {side_label} Front Stringer",
     )
 
-    back_rail = timber_from_directions(
+    back_rail = create_timber(
         length=ladder_height,
         size=rail_size,
         bottom_position=back_bottom_global,
@@ -95,7 +95,7 @@ def _create_half_rung_between_parallel_stringers(
         length_direction = create_v3(-1, 0, 0)
         side_text = "Right"
 
-    return timber_from_directions(
+    return create_timber(
         length=half_rung_length,
         size=step_size,
         bottom_position=rung_bottom,

--- a/garbage/new_shed.py
+++ b/garbage/new_shed.py
@@ -270,7 +270,7 @@ def create_honeycomb_shed():
     hub_post_size = create_v2(inches(6), inches(6))  # 6" x 6"
     hub_height = (post_front_height + post_back_height) / 2 + inches(12)  # Average height + 12"
     
-    hub_post = timber_from_directions(
+    hub_post = create_timber(
         length=hub_height,
         size=hub_post_size,
         bottom_position=center_point,

--- a/garbage/sillyshed_example.py
+++ b/garbage/sillyshed_example.py
@@ -153,7 +153,7 @@ def _create_roof_rafters(origin: V3) -> list[Timber]:
         back_bottom = back_plate_point - normalize_vector(back_vec) * rafter_overhang
 
         rafters.append(
-            timber_from_directions(
+            create_timber(
                 length=safe_norm(front_vec) + rafter_overhang,
                 size=rafter_size,
                 bottom_position=front_bottom,
@@ -164,7 +164,7 @@ def _create_roof_rafters(origin: V3) -> list[Timber]:
         )
 
         rafters.append(
-            timber_from_directions(
+            create_timber(
                 length=safe_norm(back_vec) + rafter_overhang,
                 size=rafter_size,
                 bottom_position=back_bottom,

--- a/kumiki/construction.py
+++ b/kumiki/construction.py
@@ -138,24 +138,6 @@ class Stickout:
 # ============================================================================
 
 
-def create_timber(bottom_position: V3, length: Numeric, size: V2, 
-                  length_direction: Direction3D, width_direction: Direction3D, ticket: Optional[Union[TimberTicket, str]] = None) -> Timber:
-    """
-    Creates a timber at bottom_position with given dimensions and rotates it 
-    to the length_direction and width_direction
-
-    AGENT NOTE: AVOID this function if possible, prefer methods like join_timber, attach_timber, create_*_timber_on_footprint, or even create_axis_aligned_timber, which are more robust and easier to use.
-    
-    Args:
-        bottom_position: Position of the bottom point of the timber
-        length: Length of the timber
-        size: Cross-sectional size (width, height)
-        length_direction: Direction vector for the timber's length axis
-        width_direction: Direction vector for the timber's width axis
-        ticket: Optional ticket for this timber (can be Ticket object or string name, used for rendering/debugging)
-    """
-    return timber_from_directions(length, size, bottom_position, length_direction, width_direction, ticket=ticket)
-
 def create_axis_aligned_timber(bottom_position: V3, length: Numeric, size: V2,
                               length_direction: TimberFace, width_direction: Optional[TimberFace] = None, 
                               ticket: Optional[Union[TimberTicket, str]] = None) -> Timber:
@@ -195,7 +177,7 @@ def create_axis_aligned_timber(bottom_position: V3, length: Numeric, size: V2,
     
     width_vec = width_direction.get_direction()
     
-    return create_timber(bottom_position, length, size, length_vec, width_vec, ticket=ticket)
+    return create_timber(length=length, size=size, bottom_position=bottom_position, length_direction=length_vec, width_direction=width_vec, ticket=ticket)
 
 def create_vertical_timber_on_footprint_corner(footprint: Footprint, corner_index: int, 
                                                length: Numeric, location_type: FootprintLocation,
@@ -284,7 +266,7 @@ def create_vertical_timber_on_footprint_corner(footprint: Footprint, corner_inde
         # Center of bottom face lies on the boundary corner.
         bottom_position = create_v3(corner_x, corner_y, scalar(0))
     
-    return create_timber(bottom_position, length, size, length_direction, width_direction, ticket=ticket)
+    return create_timber(length=length, size=size, bottom_position=bottom_position, length_direction=length_direction, width_direction=width_direction, ticket=ticket)
 
 def create_vertical_timber_on_footprint_side(footprint: Footprint, side_index: int, 
                                             distance_along_side: Numeric,
@@ -383,7 +365,7 @@ def create_vertical_timber_on_footprint_side(footprint: Footprint, side_index: i
                                          point_y - inward_y * timber_depth / scalar(2), 
                                          scalar(0))
     
-    return create_timber(bottom_position, length, size, length_direction, width_direction, ticket=ticket)
+    return create_timber(length=length, size=size, bottom_position=bottom_position, length_direction=length_direction, width_direction=width_direction, ticket=ticket)
 
 def create_horizontal_timber_on_footprint(footprint: Footprint, corner_index: int,
                                         location_type: FootprintLocation, 
@@ -452,7 +434,7 @@ def create_horizontal_timber_on_footprint(footprint: Footprint, corner_index: in
         bottom_position = bottom_position - inward_normal * (timber_height / scalar(2))
     # For CENTER, no offset needed - centerline is already on the boundary side
     
-    return create_timber(bottom_position, length, size, length_direction, width_direction, ticket=ticket)
+    return create_timber(length=length, size=size, bottom_position=bottom_position, length_direction=length_direction, width_direction=width_direction, ticket=ticket)
 
 def stretch_timber(timber: Timber, end: TimberEnd, overlap_length: Numeric, 
                   extend_length: Numeric) -> Timber:
@@ -480,7 +462,7 @@ def stretch_timber(timber: Timber, end: TimberEnd, overlap_length: Numeric,
     # Create new timber with extended length
     new_length = timber.length + extend_length + overlap_length
     
-    return timber_from_directions(new_length, timber.size, new_bottom_position, 
+    return create_timber(new_length, timber.size, new_bottom_position, 
                                    timber.get_length_direction_global(), timber.get_width_direction_global())
 
 # TODO add some sorta splice stickout parameter
@@ -525,7 +507,7 @@ def split_timber(
     top_ticket = ticket2 if ticket2 is not None else f"{timber.ticket.path}/top"
     
     # Create first timber (bottom part)
-    bottom_timber = timber_from_directions(
+    bottom_timber = create_timber(
         length=distance_from_bottom,
         size=create_v2(timber.size[0], timber.size[1]),
         bottom_position=timber.get_bottom_position_global(),
@@ -539,7 +521,7 @@ def split_timber(
     top_of_first = timber.get_bottom_position_global() + distance_from_bottom * timber.get_length_direction_global()
     
     # Create second timber (top part)
-    top_timber = timber_from_directions(
+    top_timber = create_timber(
         length=timber.length - distance_from_bottom,
         size=create_v2(timber.size[0], timber.size[1]),
         bottom_position=top_of_first,
@@ -1130,7 +1112,7 @@ def join_timbers(timber1: PerfectTimberWithin, timber2: PerfectTimberWithin,
     if lateral_offset != scalar(0):
         bottom_pos += offset_dir * lateral_offset
     
-    return create_timber(bottom_pos, timber_length, size, length_direction, width_direction, ticket=ticket)
+    return create_timber(length=timber_length, size=size, bottom_position=bottom_pos, length_direction=length_direction, width_direction=width_direction, ticket=ticket)
 
 
 def join_plane_aligned_on_place_aligned_timbers(timber1: PerfectTimberWithin, timber2: PerfectTimberWithin,

--- a/kumiki/example_shavings.py
+++ b/kumiki/example_shavings.py
@@ -11,7 +11,7 @@ from dataclasses import dataclass
 
 from kumiki.timber import (
     Timber, TimberEnd, TimberLongFace,
-    timber_from_directions, normalize_vector,
+    create_timber, normalize_vector,
     RoundTimber, MeshTimber, RegularPolygonTimber,
 )
 from kumiki.rule import (
@@ -81,7 +81,7 @@ def _create_configurable_example_timber(
     ticket: str,
     timber_config: CanonicalExampleTimberConfig,
 ) -> CanonicalExampleTimber:
-    base_timber = timber_from_directions(
+    base_timber = create_timber(
         length=length,
         size=size,
         bottom_position=bottom_position,

--- a/kumiki/timber.py
+++ b/kumiki/timber.py
@@ -402,15 +402,16 @@ def compute_timber_orientation(length_direction: Direction3D, width_direction: D
     return Orientation(rotation_matrix)
 
 
-# TODO rename to create_timber (or maybe hew lolololol) + add defaults
-def timber_from_directions(length: Numeric, size: V2, bottom_position: V3,
+def create_timber(length: Numeric, size: V2, bottom_position: V3,
                           length_direction: Direction3D, width_direction: Direction3D,
                           ticket: Optional[Union[TimberTicket, str]] = None) -> 'Timber':
     """Factory function to create a Timber with computed orientation from direction vectors
-    
+
     This is the main way to construct Timber instances. It takes direction vectors
     and computes the proper orientation matrix automatically.
-    
+
+    AGENT NOTE: AVOID this function if possible, prefer methods like join_timber, attach_timber, create_*_timber_on_footprint, or even create_axis_aligned_timber, which are more robust and easier to use.
+
     Args:
         length: Length of the timber
         size: Cross-sectional size (width, height) as 2D vector, width is the X dimension (left to right), height is the Y dimension (front to back)
@@ -434,7 +435,7 @@ class PerfectTimberWithin(ABC):
     This is an abstract base class (ABC) to prevent direct instantiation.
     All timbers contain a perfect rectangular timber within their nominal bounding box.
     
-    Note: Use timber_from_directions() factory function to construct timber instances from
+    Note: Use create_timber() factory function to construct timber instances from
     length_direction and width_direction vectors. Subclasses are frozen to ensure immutability
     after construction.
     

--- a/patterns/CSG_debug_patterns.py
+++ b/patterns/CSG_debug_patterns.py
@@ -16,7 +16,7 @@ NOTE: Prism positioning follows the Timber convention:
 from sympy import Matrix, eye, sqrt
 from kumiki.cutcsg import *
 from kumiki.rule import Orientation, Transform, inches, feet, scalar
-from kumiki.timber import Timber, TimberEnd, TimberFace, TimberLongFace, timber_from_directions
+from kumiki.timber import Timber, TimberEnd, TimberFace, TimberLongFace, create_timber
 from kumiki.construction import ButtJointTimberArrangement
 from kumiki.joints.workshop.shavings import chop_lap_on_timber_end, chop_profile_on_timber_face
 from kumiki.joints.workshop.shavings.relief import chop_shoulder_notch_on_timber_face
@@ -233,7 +233,7 @@ def example_lap_cut_on_timber():
     timber_length = 4 * foot  # 4'
     
     # Create timber extending along X-axis
-    timber = timber_from_directions(
+    timber = create_timber(
         length=timber_length,
         size=Matrix([timber_width, timber_height]),
         bottom_position=Matrix([0, 0, 0]),
@@ -298,7 +298,7 @@ def example_gooseneck_profile_cut():
     timber_length = feet(4)    # 4'
     
     # Create timber extending along Z-axis (vertical)
-    timber = timber_from_directions(
+    timber = create_timber(
         length=timber_length,
         size=Matrix([timber_width, timber_height]),
         bottom_position=Matrix([0, 0, 0]),
@@ -372,7 +372,7 @@ def example_shoulder_notch_on_timber():
     timber_length = feet(4)    # 4'
     
     # Create vertical timber extending along Z-axis
-    timber = timber_from_directions(
+    timber = create_timber(
         length=timber_length,
         size=Matrix([timber_width, timber_height]),
         bottom_position=Matrix([0, 0, 0]),
@@ -429,7 +429,7 @@ def example_chop_shoulder_notch_on_timber_face_raw():
     timber_size = inches(4)
     timber_length = feet(4)
     
-    timber = timber_from_directions(
+    timber = create_timber(
         length=timber_length,
         size=Matrix([timber_size, timber_size]),
         bottom_position=Matrix([0, 0, 0]),
@@ -469,7 +469,7 @@ def example_angled_shoulder_notch_on_timber():
     timber_size = inches(4)
     timber_length = feet(4)
     
-    timber = timber_from_directions(
+    timber = create_timber(
         length=timber_length,
         size=Matrix([timber_size, timber_size]),
         bottom_position=Matrix([0, 0, 0]),
@@ -530,7 +530,7 @@ def example_angled_shoulder_notch_on_timber():
 
 def _create_dovetail_debug_arrangement() -> ButtJointTimberArrangement:
     """Create a simple orthogonal butt arrangement used by dovetail debug examples."""
-    receiving_timber = timber_from_directions(
+    receiving_timber = create_timber(
         length=feet(5),
         size=Matrix([inches(4), inches(6)]),
         bottom_position=Matrix([0, 0, 0]),
@@ -538,7 +538,7 @@ def _create_dovetail_debug_arrangement() -> ButtJointTimberArrangement:
         width_direction=Matrix([0, 1, 0]),
         ticket='debug_receiving_timber',
     )
-    butt_timber = timber_from_directions(
+    butt_timber = create_timber(
         length=feet(4),
         size=Matrix([inches(4), inches(4)]),
         bottom_position=Matrix([inches(18), 0, -feet(2)]),

--- a/patterns/basic_joints_patterns.py
+++ b/patterns/basic_joints_patterns.py
@@ -7,7 +7,7 @@ from sympy import Matrix
 from kumiki.rule import inches, Transform, scalar
 from kumiki.timber import (
     Timber, TimberEnd, TimberFace, TimberLongFace, Peg, Wedge,
-    PegShape, timber_from_directions,
+    PegShape, create_timber,
     create_v3, V2, CutTimber, Frame
 )
 from kumiki.ticket import Ticket

--- a/patterns/butt_joints_patterns.py
+++ b/patterns/butt_joints_patterns.py
@@ -78,7 +78,7 @@ def make_tongue_and_fork_butt_joint_angled_example(position: V3, use_round_timbe
         position = create_v3(scalar(0), scalar(0), scalar(0))
 
     receiving_bottom = position + create_v3(-TIMBER_LENGTH / scalar(2), scalar(0), scalar(0))
-    receiving_timber = _maybe_round_timber(timber_from_directions(
+    receiving_timber = _maybe_round_timber(create_timber(
         length=TIMBER_LENGTH,
         size=TIMBER_SIZE_2D,
         bottom_position=receiving_bottom,
@@ -88,7 +88,7 @@ def make_tongue_and_fork_butt_joint_angled_example(position: V3, use_round_timbe
     ), use_round_timbers)
 
     butt_length_direction = create_v3(sin(angle), cos(angle), scalar(0))
-    butt_timber = _maybe_round_timber(timber_from_directions(
+    butt_timber = _maybe_round_timber(create_timber(
         length=TIMBER_LENGTH,
         size=TIMBER_SIZE_2D,
         bottom_position=position,
@@ -153,7 +153,7 @@ def make_butt_joint_3d_angles_example(position: V3, use_round_timbers=False) -> 
     sqrt5 = sqrt(5)
 
     # Receiving timber: vertical post along Z
-    receiving = _maybe_round_timber(timber_from_directions(
+    receiving = _maybe_round_timber(create_timber(
         length=TIMBER_LENGTH,
         size=TIMBER_SIZE_2D,
         bottom_position=position,
@@ -172,7 +172,7 @@ def make_butt_joint_3d_angles_example(position: V3, use_round_timbers=False) -> 
     right_face_mid = position + Matrix([TIMBER_WIDTH / 2, scalar(0), TIMBER_LENGTH / 2])
     butt_bottom = right_face_mid - TIMBER_LENGTH * dirB
 
-    butt = _maybe_round_timber(timber_from_directions(
+    butt = _maybe_round_timber(create_timber(
         length=TIMBER_LENGTH,
         size=TIMBER_SIZE_2D,
         bottom_position=butt_bottom,
@@ -197,7 +197,7 @@ from sympy import Matrix
 from kumiki.rule import inches, Transform, degrees
 from kumiki.timber import (
     Timber, TimberEnd, TimberFace, TimberLongFace, Peg, Wedge,
-    PegShape, timber_from_directions,
+    PegShape, create_timber,
     create_v3, V2, CutTimber, Frame
 )
 

--- a/patterns/construction_patterns.py
+++ b/patterns/construction_patterns.py
@@ -23,7 +23,7 @@ def make_join_face_aligned_on_face_aligned_timbers_example():
     beam_size = create_v2(inches(4), inches(4))
     
     # Create left post at origin
-    post_left = timber_from_directions(
+    post_left = create_timber(
         length=post_height,
         size=post_size,
         bottom_position=create_v3(0, 0, 0),
@@ -33,7 +33,7 @@ def make_join_face_aligned_on_face_aligned_timbers_example():
     )
     
     # Create right post 4' away in X direction
-    post_right = timber_from_directions(
+    post_right = create_timber(
         length=post_height,
         size=post_size,
         bottom_position=create_v3(feet(4), 0, 0),
@@ -76,7 +76,7 @@ def make_attach_face_aligned_timber_example():
     post_height = inches(96)
     beam_size = create_v2(inches(4), inches(6))
 
-    post = timber_from_directions(
+    post = create_timber(
         length=post_height,
         size=post_size,
         bottom_position=create_v3(0, 0, 0),
@@ -131,7 +131,7 @@ def make_attach_face_aligned_timber_stickout_example(reference: StickoutReferenc
     attached_size = create_v2(inches(4), inches(4))
     span = feet(3)
 
-    post = timber_from_directions(
+    post = create_timber(
         length=post_height,
         size=post_size,
         bottom_position=create_v3(0, 0, 0),
@@ -140,7 +140,7 @@ def make_attach_face_aligned_timber_stickout_example(reference: StickoutReferenc
         ticket="Post",
     )
 
-    target_post = timber_from_directions(
+    target_post = create_timber(
         length=post_height,
         size=post_size,
         bottom_position=create_v3(span, 0, 0),
@@ -181,7 +181,7 @@ def make_attach_face_aligned_timber_target_projection_example():
     attached_size = create_v2(inches(4), inches(4))
     span = feet(3)
 
-    post = timber_from_directions(
+    post = create_timber(
         length=post_height,
         size=post_size,
         bottom_position=create_v3(0, 0, 0),
@@ -190,7 +190,7 @@ def make_attach_face_aligned_timber_target_projection_example():
         ticket="Post",
     )
 
-    target_post = timber_from_directions(
+    target_post = create_timber(
         length=post_height,
         size=post_size,
         bottom_position=create_v3(span, inches(8), 0),
@@ -234,7 +234,7 @@ def make_attach_face_aligned_timber_flush_example():
     post_height = feet(8)
     attached_size = create_v2(inches(5), inches(7))
 
-    post = timber_from_directions(
+    post = create_timber(
         length=post_height,
         size=post_size,
         bottom_position=create_v3(0, 0, 0),
@@ -277,7 +277,7 @@ def make_attach_plane_aligned_timber_brace_example():
     post_height = feet(8)
     brace_size = create_v2(inches(4), inches(4))
 
-    post = timber_from_directions(
+    post = create_timber(
         length=post_height,
         size=post_size,
         bottom_position=create_v3(0, 0, 0),
@@ -317,7 +317,7 @@ def make_attach_timber_example():
     post_height = feet(8)
     attached_size = create_v2(inches(4), inches(4))
 
-    post = timber_from_directions(
+    post = create_timber(
         length=post_height,
         size=post_size,
         bottom_position=create_v3(0, 0, 0),

--- a/patterns/corner_joints_patterns.py
+++ b/patterns/corner_joints_patterns.py
@@ -135,7 +135,7 @@ def make_miter_joint_3d_angles_example(position: V3, use_round_timbers=False) ->
     # (-4,2,0)/sqrt(20) = (-2,1,0)/sqrt(5) is perpendicular to dirB: 2*(-2)+4*1+3*0 = 0
     widthB = Matrix([scalar(-2), scalar(1), scalar(0)]) / sqrt5
 
-    timberA = _maybe_round_timber(timber_from_directions(
+    timberA = _maybe_round_timber(create_timber(
         length=TIMBER_LENGTH,
         size=TIMBER_SIZE_2D,
         bottom_position=position,
@@ -143,7 +143,7 @@ def make_miter_joint_3d_angles_example(position: V3, use_round_timbers=False) ->
         width_direction=widthA,
         ticket=TimberTicket("MiterWeird_TimberA"),
     ), use_round_timbers)
-    timberB = _maybe_round_timber(timber_from_directions(
+    timberB = _maybe_round_timber(create_timber(
         length=TIMBER_LENGTH,
         size=TIMBER_SIZE_2D,
         bottom_position=position,

--- a/patterns/cross_joints_patterns.py
+++ b/patterns/cross_joints_patterns.py
@@ -70,7 +70,7 @@ def make_house_joint_example(position: V3, use_round_timbers=False) -> list[CutT
 
     # Housing timber (beam) extends in +X direction
     # This is the timber that gets the groove cut into it
-    housing_timber = _maybe_round_timber(timber_from_directions(
+    housing_timber = _maybe_round_timber(create_timber(
         ticket="HouseJoint_Housing",
         length=TIMBER_LENGTH,
         size=TIMBER_SIZE_2D,
@@ -82,7 +82,7 @@ def make_house_joint_example(position: V3, use_round_timbers=False) -> list[CutT
     # Housed timber (shelf) extends in +Y direction, crossing through the housing timber
     # This timber fits into the groove and remains uncut
     # Offset vertically so they intersect properly
-    housed_timber = _maybe_round_timber(timber_from_directions(
+    housed_timber = _maybe_round_timber(create_timber(
         ticket="HouseJoint_Housed",
         length=TIMBER_LENGTH,
         size=TIMBER_SIZE_2D,
@@ -118,7 +118,7 @@ def make_cross_lap_joint_example(position: V3, use_round_timbers=False) -> list[
 
     # TimberA extends in +X direction, bottom at Z=0 (relative to position)
     # Height direction is +Z, so top face is at Z=TIMBER_HEIGHT
-    timberA = _maybe_round_timber(timber_from_directions(
+    timberA = _maybe_round_timber(create_timber(
         ticket="CrossLap_TimberA",
         length=TIMBER_LENGTH,
         size=TIMBER_SIZE_2D,
@@ -130,7 +130,7 @@ def make_cross_lap_joint_example(position: V3, use_round_timbers=False) -> list[
     # TimberB extends in +Y direction, bottom at Z=half_height (relative to position)
     # This creates an overlap from Z=half_height to Z=TIMBER_HEIGHT
     # Height direction is +Z, so top face is at Z=half_height+TIMBER_HEIGHT
-    timberB = _maybe_round_timber(timber_from_directions(
+    timberB = _maybe_round_timber(create_timber(
         ticket="CrossLap_TimberB",
         length=TIMBER_LENGTH,
         size=TIMBER_SIZE_2D,

--- a/patterns/irrational_angles_patterns.py
+++ b/patterns/irrational_angles_patterns.py
@@ -7,7 +7,7 @@ representations are converted to floating point values in CAD systems.
 """
 
 from sympy import pi, Matrix, cos, sin
-from kumiki.timber import Frame, TimberFace, TimberEnd, create_v3, timber_from_directions
+from kumiki.timber import Frame, TimberFace, TimberEnd, create_v3, create_timber
 from kumiki.construction import ButtJointTimberArrangement
 from kumiki.joints.workshop.butt_joints import cut_mortise_and_tenon_joint
 from kumiki.patternbook import Pattern
@@ -22,7 +22,7 @@ def create_all_irrational_examples() -> Frame:
     at irrational angles and SymPy values are converted to floats.
     """
     # Vertical post (mortise timber)
-    post = timber_from_directions(
+    post = create_timber(
         length=scalar(96),
         size=Matrix([scalar(6), scalar(6)]),
         bottom_position=create_v3(scalar(0), scalar(0), scalar(0)),
@@ -38,7 +38,7 @@ def create_all_irrational_examples() -> Frame:
     length_dir = create_v3(cos(angle_37), sin(angle_37), scalar(0))
     width_dir = create_v3(scalar(0), scalar(0), scalar(1))
     
-    beam = timber_from_directions(
+    beam = create_timber(
         length=scalar(60),
         size=Matrix([scalar(4), scalar(6)]),
         bottom_position=create_v3(scalar(0), scalar(0), scalar(48)),

--- a/patterns/patternbook_patterns.py
+++ b/patterns/patternbook_patterns.py
@@ -7,22 +7,22 @@ from kumiki.patternbook import Pattern
 
 
 def _make_short_post(center):
-    return Frame(cut_timbers=[CutTimber(timber_from_directions(length=feet(4), size=create_v2(inches(4), inches(4)), bottom_position=center, length_direction=create_v3(scalar(0), scalar(0), scalar(1)), width_direction=create_v3(scalar(1), scalar(0), scalar(0)), ticket="short_post"), cuts=[])], name="Short Post")
+    return Frame(cut_timbers=[CutTimber(create_timber(length=feet(4), size=create_v2(inches(4), inches(4)), bottom_position=center, length_direction=create_v3(scalar(0), scalar(0), scalar(1)), width_direction=create_v3(scalar(1), scalar(0), scalar(0)), ticket="short_post"), cuts=[])], name="Short Post")
 
 def _make_tall_post(center):
-    return Frame(cut_timbers=[CutTimber(timber_from_directions(length=feet(8), size=create_v2(inches(6), inches(6)), bottom_position=center, length_direction=create_v3(scalar(0), scalar(0), scalar(1)), width_direction=create_v3(scalar(1), scalar(0), scalar(0)), ticket="tall_post"), cuts=[])], name="Tall Post")
+    return Frame(cut_timbers=[CutTimber(create_timber(length=feet(8), size=create_v2(inches(6), inches(6)), bottom_position=center, length_direction=create_v3(scalar(0), scalar(0), scalar(1)), width_direction=create_v3(scalar(1), scalar(0), scalar(0)), ticket="tall_post"), cuts=[])], name="Tall Post")
 
 def _make_wide_post(center):
-    return Frame(cut_timbers=[CutTimber(timber_from_directions(length=feet(6), size=create_v2(inches(8), inches(8)), bottom_position=center, length_direction=create_v3(scalar(0), scalar(0), scalar(1)), width_direction=create_v3(scalar(1), scalar(0), scalar(0)), ticket="wide_post"), cuts=[])], name="Wide Post")
+    return Frame(cut_timbers=[CutTimber(create_timber(length=feet(6), size=create_v2(inches(8), inches(8)), bottom_position=center, length_direction=create_v3(scalar(0), scalar(0), scalar(1)), width_direction=create_v3(scalar(1), scalar(0), scalar(0)), ticket="wide_post"), cuts=[])], name="Wide Post")
 
 def _make_small_beam(center):
-    return Frame(cut_timbers=[CutTimber(timber_from_directions(length=feet(8), size=create_v2(inches(2), inches(4)), bottom_position=center, length_direction=create_v3(scalar(1), scalar(0), scalar(0)), width_direction=create_v3(scalar(0), scalar(1), scalar(0)), ticket="small_beam"), cuts=[])], name="Small Beam")
+    return Frame(cut_timbers=[CutTimber(create_timber(length=feet(8), size=create_v2(inches(2), inches(4)), bottom_position=center, length_direction=create_v3(scalar(1), scalar(0), scalar(0)), width_direction=create_v3(scalar(0), scalar(1), scalar(0)), ticket="small_beam"), cuts=[])], name="Small Beam")
 
 def _make_medium_beam(center):
-    return Frame(cut_timbers=[CutTimber(timber_from_directions(length=feet(10), size=create_v2(inches(4), inches(6)), bottom_position=center, length_direction=create_v3(scalar(1), scalar(0), scalar(0)), width_direction=create_v3(scalar(0), scalar(1), scalar(0)), ticket="medium_beam"), cuts=[])], name="Medium Beam")
+    return Frame(cut_timbers=[CutTimber(create_timber(length=feet(10), size=create_v2(inches(4), inches(6)), bottom_position=center, length_direction=create_v3(scalar(1), scalar(0), scalar(0)), width_direction=create_v3(scalar(0), scalar(1), scalar(0)), ticket="medium_beam"), cuts=[])], name="Medium Beam")
 
 def _make_large_beam(center):
-    return Frame(cut_timbers=[CutTimber(timber_from_directions(length=feet(12), size=create_v2(inches(6), inches(8)), bottom_position=center, length_direction=create_v3(scalar(1), scalar(0), scalar(0)), width_direction=create_v3(scalar(0), scalar(1), scalar(0)), ticket="large_beam"), cuts=[])], name="Large Beam")
+    return Frame(cut_timbers=[CutTimber(create_timber(length=feet(12), size=create_v2(inches(6), inches(8)), bottom_position=center, length_direction=create_v3(scalar(1), scalar(0), scalar(0)), width_direction=create_v3(scalar(0), scalar(1), scalar(0)), ticket="large_beam"), cuts=[])], name="Large Beam")
 
 def _make_small_box(center):
     size = inches(2)

--- a/tests/joints/shavings/test_build_a_butt.py
+++ b/tests/joints/shavings/test_build_a_butt.py
@@ -7,7 +7,7 @@ from sympy import cos, sin, pi
 from kumiki.rule import create_v2, inches, radians, are_vectors_parallel, zero_test, safe_dot_product, safe_normalize_vector as normalize_vector, safe_compare, Comparison, scalar
 from kumiki.timber import (
     TimberEnd,
-    timber_from_directions, create_v3
+    create_timber, create_v3
 )
 from kumiki.construction import ButtJointTimberArrangement
 from kumiki.joints.workshop.shavings.build_a_butt import locate_mortise_timber_shoulder_plane_from_centerline_towards_tenon_timber
@@ -60,7 +60,7 @@ class TestMeasureMortiseShoulderPlane:
         """
         angle_rad = radians(scalar(2, 9) * pi)  # 40 degrees
 
-        mortise_timber = timber_from_directions(
+        mortise_timber = create_timber(
             length=inches(48), size=create_v2(inches(4), inches(5)),
             bottom_position=create_v3(-inches(24), scalar(0), scalar(0)),
             length_direction=create_v3(scalar(1), scalar(0), scalar(0)),
@@ -68,7 +68,7 @@ class TestMeasureMortiseShoulderPlane:
             ticket="mortise"
         )
         tenon_length_dir = create_v3(cos(angle_rad), sin(angle_rad), scalar(0))
-        tenon_timber = timber_from_directions(
+        tenon_timber = create_timber(
             length=inches(48), size=create_v2(inches(4), inches(5)),
             bottom_position=create_v3(-inches(24) * cos(angle_rad), -inches(24) * sin(angle_rad), inches(3)),
             length_direction=tenon_length_dir,

--- a/tests/joints/shavings/test_relief.py
+++ b/tests/joints/shavings/test_relief.py
@@ -22,7 +22,7 @@ from kumiki.timber import (
     TimberFace,
     TimberEnd,
     create_v3,
-    timber_from_directions,
+    create_timber,
 )
 from kumiki.timber_shavings import are_timbers_plane_aligned
 from tests.testing_shavings import (
@@ -80,7 +80,7 @@ class TestShoulderNotchingDecision:
         assert does_shoulder_plane_need_notching(aligned_arrangement, face_half_size - scalar(1))
         assert not does_shoulder_plane_need_notching(aligned_arrangement, face_half_size)
 
-        non_plane_mortise = timber_from_directions(
+        non_plane_mortise = create_timber(
             length=scalar(100),
             size=create_v2(scalar(6), scalar(6)),
             bottom_position=create_v3(-scalar(50), scalar(0), scalar(0)),
@@ -88,7 +88,7 @@ class TestShoulderNotchingDecision:
             width_direction=create_v3(scalar(0), scalar(0), scalar(1)),
             ticket="non_plane_mortise",
         )
-        non_plane_tenon = timber_from_directions(
+        non_plane_tenon = create_timber(
             length=scalar(100),
             size=create_v2(scalar(4), scalar(4)),
             bottom_position=create_v3(scalar(0), scalar(0), scalar(0)),
@@ -166,7 +166,7 @@ class TestChopScribeRelief:
             ticket="timber_to_be_cut",
         )
         timber_to_be_scribed = replace(
-            timber_from_directions(
+            create_timber(
                 length=scalar(20),
                 size=create_v2(scalar(4), scalar(4)),
                 bottom_position=create_v3(scalar(0), scalar(0), scalar(0)),

--- a/tests/joints/shavings/test_shavings.py
+++ b/tests/joints/shavings/test_shavings.py
@@ -12,7 +12,7 @@ from kumiki.joints.workshop.shavings.shavings import (
     scribe_centerline_onto_centerline
 )
 from kumiki.joints.workshop.shavings.relief import chop_shoulder_notch_on_timber_face
-from kumiki.timber import timber_from_directions, TimberEnd, TimberFace, TimberLongFace
+from kumiki.timber import create_timber, TimberEnd, TimberFace, TimberLongFace
 from kumiki.rule import create_v3, create_v2, inches, are_vectors_parallel, scalar
 from kumiki.cutcsg import SolidUnion, RectangularPrism, HalfSpace
 from kumiki.measuring import mark_distance_from_end_along_centerline
@@ -28,7 +28,7 @@ class TestCheckTimberOverlapForSpliceJoint:
         timber_size = create_v2(inches(4), inches(4))
         
         # TimberA pointing east (left to right)
-        timberA = timber_from_directions(
+        timberA = create_timber(
             length=timber_length,
             size=timber_size,
             bottom_position=create_v3(0, 0, 0),
@@ -39,7 +39,7 @@ class TestCheckTimberOverlapForSpliceJoint:
         
         # TimberB pointing west (right to left), positioned to overlap
         # For timbers pointing opposite directions, join matching ends (TOP to TOP)
-        timberB = timber_from_directions(
+        timberB = create_timber(
             length=timber_length,
             size=timber_size,
             bottom_position=create_v3(timber_length * 2, 0, 0),
@@ -61,7 +61,7 @@ class TestCheckTimberOverlapForSpliceJoint:
         timber_size = create_v2(inches(4), inches(4))
         
         # TimberA pointing east
-        timberA = timber_from_directions(
+        timberA = create_timber(
             length=timber_length,
             size=timber_size,
             bottom_position=create_v3(0, 0, 0),
@@ -72,7 +72,7 @@ class TestCheckTimberOverlapForSpliceJoint:
         
         # TimberB pointing west, TOP ends exactly touch
         # For opposite direction timbers, join matching ends so they face each other
-        timberB = timber_from_directions(
+        timberB = create_timber(
             length=timber_length,
             size=timber_size,
             bottom_position=create_v3(2 * timber_length, 0, 0),  # Start further right
@@ -94,7 +94,7 @@ class TestCheckTimberOverlapForSpliceJoint:
         timber_size = create_v2(inches(4), inches(4))
         
         # Both timbers pointing east
-        timberA = timber_from_directions(
+        timberA = create_timber(
             length=timber_length,
             size=timber_size,
             bottom_position=create_v3(0, 0, 0),
@@ -103,7 +103,7 @@ class TestCheckTimberOverlapForSpliceJoint:
             ticket="timberA"
         )
         
-        timberB = timber_from_directions(
+        timberB = create_timber(
             length=timber_length,
             size=timber_size,
             bottom_position=create_v3(timber_length, 0, 0),
@@ -128,7 +128,7 @@ class TestCheckTimberOverlapForSpliceJoint:
         timber_size = create_v2(inches(4), inches(4))
         
         # TimberA pointing east
-        timberA = timber_from_directions(
+        timberA = create_timber(
             length=timber_length,
             size=timber_size,
             bottom_position=create_v3(0, 0, 0),
@@ -138,7 +138,7 @@ class TestCheckTimberOverlapForSpliceJoint:
         )
         
         # TimberB pointing up (perpendicular, not parallel)
-        timberB = timber_from_directions(
+        timberB = create_timber(
             length=timber_length,
             size=timber_size,
             bottom_position=create_v3(timber_length, 0, 0),
@@ -161,7 +161,7 @@ class TestCheckTimberOverlapForSpliceJoint:
         gap = inches(6)  # 6 inch gap
         
         # TimberA pointing east, TOP end at inches(36)
-        timberA = timber_from_directions(
+        timberA = create_timber(
             length=timber_length,
             size=timber_size,
             bottom_position=create_v3(0, 0, 0),
@@ -172,7 +172,7 @@ class TestCheckTimberOverlapForSpliceJoint:
         
         # TimberB pointing west, TOP end at inches(36-6)=inches(30)
         # So there's a 6 inch gap between timberA's TOP and timberB's TOP
-        timberB = timber_from_directions(
+        timberB = create_timber(
             length=timber_length,
             size=timber_size,
             bottom_position=create_v3(inches(30) - timber_length, 0, 0),  # Bottom at -6 inches
@@ -194,7 +194,7 @@ class TestCheckTimberOverlapForSpliceJoint:
         timber_size = create_v2(inches(6), inches(6))
         
         # TimberA pointing up (vertical post)
-        timberA = timber_from_directions(
+        timberA = create_timber(
             length=timber_length,
             size=timber_size,
             bottom_position=create_v3(0, 0, 0),
@@ -207,7 +207,7 @@ class TestCheckTimberOverlapForSpliceJoint:
         # For opposite direction timbers, join matching ends (TOP to TOP)
         # TimberA TOP is at z=timber_length
         # Position TimberB so its TOP is at z=1.5*timber_length (overlapping)
-        timberB = timber_from_directions(
+        timberB = create_timber(
             length=timber_length,
             size=timber_size,
             bottom_position=create_v3(0, 0, timber_length * scalar(5, 2)),  # Start at 2.5*L
@@ -227,7 +227,7 @@ class TestCheckTimberOverlapForSpliceJoint:
         """Test validation works with different sized timbers."""
         # 4x4 timber, 36 inches long
         timberA_length = inches(36)
-        timberA = timber_from_directions(
+        timberA = create_timber(
             length=timberA_length,
             size=create_v2(inches(4), inches(4)),
             bottom_position=create_v3(0, 0, 0),
@@ -241,7 +241,7 @@ class TestCheckTimberOverlapForSpliceJoint:
         # TimberA TOP is at x=36"
         # Position TimberB so its TOP is at x=48" (overlapping)
         timberB_length = inches(48)
-        timberB = timber_from_directions(
+        timberB = create_timber(
             length=timberB_length,
             size=create_v2(inches(6), inches(8)),
             bottom_position=create_v3(timberA_length + timberB_length, 0, 0),  # Start at 84"
@@ -264,7 +264,7 @@ class TestCheckTimberOverlapForSpliceJoint:
         timber_size = create_v2(inches(4), inches(4))
         
         # Both timbers pointing east (e.g., split from same timber)
-        timberA = timber_from_directions(
+        timberA = create_timber(
             length=timber_length,
             size=timber_size,
             bottom_position=create_v3(0, 0, 0),
@@ -273,7 +273,7 @@ class TestCheckTimberOverlapForSpliceJoint:
             ticket="timberA"
         )
         
-        timberB = timber_from_directions(
+        timberB = create_timber(
             length=timber_length,
             size=timber_size,
             bottom_position=create_v3(timber_length, 0, 0),
@@ -295,7 +295,7 @@ class TestCheckTimberOverlapForSpliceJoint:
         timber_length = inches(36)
         timber_size = create_v2(inches(4), inches(4))
         
-        timberA = timber_from_directions(
+        timberA = create_timber(
             length=timber_length,
             size=timber_size,
             bottom_position=create_v3(0, 0, 0),
@@ -304,7 +304,7 @@ class TestCheckTimberOverlapForSpliceJoint:
             ticket="timberA"
         )
         
-        timberB = timber_from_directions(
+        timberB = create_timber(
             length=timber_length,
             size=timber_size,
             bottom_position=create_v3(timber_length * 2, 0, 0),
@@ -335,7 +335,7 @@ class TestChopTimberEndWithPrism:
     def test_chop_top_end(self):
         """Test chopping from the top end of a timber."""
         # Create a simple vertical timber: 4x4 inches, 10 feet tall
-        timber = timber_from_directions(
+        timber = create_timber(
             length=inches(120),  # 10 feet
             size=create_v2(inches(4), inches(4)),
             bottom_position=create_v3(0, 0, 0),
@@ -362,7 +362,7 @@ class TestChopTimberEndWithPrism:
     def test_chop_bottom_end(self):
         """Test chopping from the bottom end of a timber."""
         # Create a simple vertical timber: 4x4 inches, 10 feet tall
-        timber = timber_from_directions(
+        timber = create_timber(
             length=inches(120),  # 10 feet
             size=create_v2(inches(4), inches(4)),
             bottom_position=create_v3(0, 0, 0),
@@ -388,7 +388,7 @@ class TestChopTimberEndWithPrism:
     def test_chop_horizontal_timber(self):
         """Test chopping a horizontal timber to ensure it works in any orientation."""
         # Create a horizontal timber pointing east
-        timber = timber_from_directions(
+        timber = create_timber(
             length=inches(48),  # 4 feet
             size=create_v2(inches(6), inches(6)),
             bottom_position=create_v3(0, 0, 0),
@@ -409,7 +409,7 @@ class TestChopTimberEndWithPrism:
     
     def test_chop_with_rational_distances(self):
         """Test that the function works with Rational arithmetic."""
-        timber = timber_from_directions(
+        timber = create_timber(
             length=scalar(10),
             size=create_v2(scalar(2), scalar(2)),
             bottom_position=create_v3(0, 0, 0),
@@ -434,7 +434,7 @@ class TestChopTimberEndWithHalfspace:
     def test_chop_top_end(self):
         """Test chopping from the top end of a timber with a half-plane."""
         # Create a simple vertical timber: 4x4 inches, 10 feet tall
-        timber = timber_from_directions(
+        timber = create_timber(
             length=inches(120),  # 10 feet
             size=create_v2(inches(4), inches(4)),
             bottom_position=create_v3(0, 0, 0),
@@ -456,7 +456,7 @@ class TestChopTimberEndWithHalfspace:
     def test_chop_bottom_end(self):
         """Test chopping from the bottom end of a timber with a half-plane."""
         # Create a simple vertical timber: 4x4 inches, 10 feet tall
-        timber = timber_from_directions(
+        timber = create_timber(
             length=inches(120),  # 10 feet
             size=create_v2(inches(4), inches(4)),
             bottom_position=create_v3(0, 0, 0),
@@ -477,7 +477,7 @@ class TestChopTimberEndWithHalfspace:
     
     def test_chop_with_rational_distances(self):
         """Test that the function works with Rational arithmetic."""
-        timber = timber_from_directions(
+        timber = create_timber(
             length=scalar(10),
             size=create_v2(scalar(2), scalar(2)),
             bottom_position=create_v3(0, 0, 0),
@@ -509,7 +509,7 @@ class TestChopLapOnTimberEnd:
         Tests boundary points and verifies CSG structure.
         """
         # Create a 4"x6" timber that is 4 ft long
-        timber = timber_from_directions(
+        timber = create_timber(
             length=inches(48),  # 4 ft
             size=create_v2(inches(4), inches(6)),  # 4" wide x 6" high
             bottom_position=create_v3(0, 0, 0),
@@ -608,7 +608,7 @@ class TestChopShoulderNotchOnTimberFace:
         timber_height = inches(4)
         timber_length = inches(48)  # 4 feet
         
-        timber = timber_from_directions(
+        timber = create_timber(
             length=timber_length,
             size=create_v2(timber_width, timber_height),
             bottom_position=create_v3(0, 0, 0),
@@ -680,7 +680,7 @@ class TestScribeFaceOnCenterline:
         Classic butt joint scenario: horizontal timber approaching a vertical face.
         """
         # Create timber_a pointing east (horizontal)
-        timber_a = timber_from_directions(
+        timber_a = create_timber(
             length=inches(48),  # 4 feet
             size=create_v2(inches(4), inches(4)),
             bottom_position=create_v3(0, 0, inches(4)),  # 4 inches above ground
@@ -691,7 +691,7 @@ class TestScribeFaceOnCenterline:
         # timber_a's TOP end is at (48", 0, 4"), centerline runs along x-axis
         
         # Create timber_b vertical with LEFT face that will intersect timber_a's centerline
-        timber_b = timber_from_directions(
+        timber_b = create_timber(
             length=inches(96),  # 8 feet tall
             size=create_v2(inches(6), inches(6)),
             bottom_position=create_v3(inches(60), 0, 0),  # Bottom at x=60"
@@ -724,7 +724,7 @@ class TestScribeFaceOnCenterline:
         Test scribing between a vertical timber and a horizontal timber's vertical face.
         """
         # Create timber_a pointing up
-        timber_a = timber_from_directions(
+        timber_a = create_timber(
             length=inches(96),  # 8 feet
             size=create_v2(inches(4), inches(4)),
             bottom_position=create_v3(0, 0, 0),
@@ -735,7 +735,7 @@ class TestScribeFaceOnCenterline:
         # timber_a's TOP end is at (0, 0, 96"), centerline runs along z-axis
         
         # Create timber_b horizontal so its BACK face (pointing down) intersects timber_a's centerline
-        timber_b = timber_from_directions(
+        timber_b = create_timber(
             length=inches(48),  # 4 feet
             size=create_v2(inches(6), inches(6)),
             bottom_position=create_v3(inches(-10), 0, inches(50)),  # BACK face at z=50"-3"=47"
@@ -766,7 +766,7 @@ class TestScribeFaceOnCenterline:
     def test_scribe_from_bottom_end(self, symbolic_mode):
         """Test scribing from the BOTTOM end of a timber."""
         # Create timber_a pointing up
-        timber_a = timber_from_directions(
+        timber_a = create_timber(
             length=inches(96),  # 8 feet
             size=create_v2(inches(4), inches(4)),
             bottom_position=create_v3(0, 0, inches(12)),  # Bottom at z=12"
@@ -778,7 +778,7 @@ class TestScribeFaceOnCenterline:
         # timber_a's TOP end is at (0, 0, 108")
         
         # Create timber_b horizontal with FRONT face (pointing up) intersecting timber_a's centerline
-        timber_b = timber_from_directions(
+        timber_b = create_timber(
             length=inches(48),  # 4 feet
             size=create_v2(inches(6), inches(6)),
             bottom_position=create_v3(0, 0, 0),  # FRONT face at z=3"
@@ -809,7 +809,7 @@ class TestScribeFaceOnCenterline:
     def test_scribe_to_end_face_top(self, symbolic_mode):
         """Test scribing to an upward-pointing face."""
         # Create timber_a vertical
-        timber_a = timber_from_directions(
+        timber_a = create_timber(
             length=inches(48),  # 4 feet
             size=create_v2(inches(4), inches(4)),
             bottom_position=create_v3(0, 0, 0),
@@ -820,7 +820,7 @@ class TestScribeFaceOnCenterline:
         # timber_a's TOP end is at (0, 0, 48"), centerline runs along z-axis
         
         # Create timber_b horizontal with its FRONT face (pointing up) intersecting timber_a's centerline
-        timber_b = timber_from_directions(
+        timber_b = create_timber(
             length=inches(60),  # 5 feet
             size=create_v2(inches(6), inches(6)),
             bottom_position=create_v3(inches(-10), 0, inches(27)),  # FRONT face at z=27"+3"=30"
@@ -851,7 +851,7 @@ class TestScribeFaceOnCenterline:
     def test_scribe_to_long_face(self, symbolic_mode):
         """Test scribing to a long face (FRONT/BACK/LEFT/RIGHT)."""
         # Create timber_a horizontal
-        timber_a = timber_from_directions(
+        timber_a = create_timber(
             length=inches(36),  # 3 feet
             size=create_v2(inches(4), inches(4)),
             bottom_position=create_v3(0, 0, 0),
@@ -862,7 +862,7 @@ class TestScribeFaceOnCenterline:
         # timber_a's TOP end is at x=36"
         
         # Create timber_b vertical
-        timber_b = timber_from_directions(
+        timber_b = create_timber(
             length=inches(96),  # 8 feet
             size=create_v2(inches(6), inches(6)),
             bottom_position=create_v3(inches(50), 0, 0),
@@ -895,7 +895,7 @@ class TestScribeFaceOnCenterline:
     def test_with_rational_arithmetic(self, symbolic_mode):
         """Test that the function works correctly with exact Rational arithmetic."""
         # Create timber_a vertical with Rational dimensions
-        timber_a = timber_from_directions(
+        timber_a = create_timber(
             length=scalar(10),
             size=create_v2(scalar(2), scalar(2)),
             bottom_position=create_v3(0, 0, 0),
@@ -906,7 +906,7 @@ class TestScribeFaceOnCenterline:
         # timber_a's TOP end is at (0, 0, 10), centerline runs along z-axis
         
         # Create timber_b horizontal with its BACK face (pointing down) intersecting timber_a's centerline
-        timber_b = timber_from_directions(
+        timber_b = create_timber(
             length=scalar(20),
             size=create_v2(scalar(3), scalar(3)),
             bottom_position=create_v3(scalar(-5), 0, scalar(7) + scalar(3)/2),  # BACK face at z=7
@@ -937,7 +937,7 @@ class TestScribeFaceOnCenterline:
     def test_positive_distance_into_timber(self, symbolic_mode):
         """Test a case where the intersection is in the positive direction (into the timber)."""
         # Create timber_a pointing east
-        timber_a = timber_from_directions(
+        timber_a = create_timber(
             length=inches(48),  # 4 feet
             size=create_v2(inches(4), inches(4)),
             bottom_position=create_v3(0, 0, 0),
@@ -948,7 +948,7 @@ class TestScribeFaceOnCenterline:
         # timber_a's TOP end is at (48", 0, 0), centerline runs along x-axis
         
         # Create timber_b vertical with LEFT face that intersects at x=36" (before timber_a's TOP end)
-        timber_b = timber_from_directions(
+        timber_b = create_timber(
             length=inches(60),  # 5 feet
             size=create_v2(inches(6), inches(6)),
             bottom_position=create_v3(inches(36), 0, 0),  # LEFT face at x=36"-3"=33"
@@ -979,7 +979,7 @@ class TestScribeFaceOnCenterline:
     def test_different_timber_sizes(self, symbolic_mode):
         """Test scribing between timbers of different cross-sectional sizes."""
         # Create small timber_a
-        timber_a = timber_from_directions(
+        timber_a = create_timber(
             length=inches(24),  # 2 feet
             size=create_v2(inches(2), inches(4)),  # 2x4
             bottom_position=create_v3(0, 0, 0),
@@ -990,7 +990,7 @@ class TestScribeFaceOnCenterline:
         # timber_a's TOP end is at z=24"
         
         # Create larger timber_b
-        timber_b = timber_from_directions(
+        timber_b = create_timber(
             length=inches(48),  # 4 feet
             size=create_v2(inches(8), inches(8)),  # 8x8
             bottom_position=create_v3(0, 0, inches(36)),  # Start at z=36"
@@ -1025,7 +1025,7 @@ class TestFindProjectedIntersectionOnCenterlines:
     def test_orthogonal_timbers_t_joint(self, symbolic_mode):
         """Test with orthogonal timbers forming a T-joint."""
         # Vertical timber (receiving)
-        timber_vertical = timber_from_directions(
+        timber_vertical = create_timber(
             length=inches(36),
             size=create_v2(inches(4), inches(4)),
             bottom_position=create_v3(0, 0, 0),
@@ -1035,7 +1035,7 @@ class TestFindProjectedIntersectionOnCenterlines:
         )
         
         # Horizontal timber intersecting at middle of vertical
-        timber_horizontal = timber_from_directions(
+        timber_horizontal = create_timber(
             length=inches(24),
             size=create_v2(inches(4), inches(4)),
             bottom_position=create_v3(0, inches(12), inches(18)),  # 18" up on vertical
@@ -1063,7 +1063,7 @@ class TestFindProjectedIntersectionOnCenterlines:
     def test_parallel_timbers(self):
         """Test with parallel timbers - should return zero distances."""
         # Two parallel timbers
-        timberA = timber_from_directions(
+        timberA = create_timber(
             length=inches(36),
             size=create_v2(inches(4), inches(4)),
             bottom_position=create_v3(0, 0, 0),
@@ -1072,7 +1072,7 @@ class TestFindProjectedIntersectionOnCenterlines:
             ticket="timberA"
         )
         
-        timberB = timber_from_directions(
+        timberB = create_timber(
             length=inches(36),
             size=create_v2(inches(4), inches(4)),
             bottom_position=create_v3(0, inches(6), 0),  # 6" away parallel
@@ -1091,7 +1091,7 @@ class TestFindProjectedIntersectionOnCenterlines:
     def test_with_different_reference_ends(self, symbolic_mode):
         """Test measuring from different reference ends (TOP vs BOTTOM)."""
         # Vertical timber
-        timber_vertical = timber_from_directions(
+        timber_vertical = create_timber(
             length=inches(36),
             size=create_v2(inches(4), inches(4)),
             bottom_position=create_v3(0, 0, 0),
@@ -1101,7 +1101,7 @@ class TestFindProjectedIntersectionOnCenterlines:
         )
         
         # Horizontal timber at middle
-        timber_horizontal = timber_from_directions(
+        timber_horizontal = create_timber(
             length=inches(24),
             size=create_v2(inches(4), inches(4)),
             bottom_position=create_v3(0, inches(12), inches(18)),

--- a/tests/joints/test_butt_joints.py
+++ b/tests/joints/test_butt_joints.py
@@ -261,7 +261,7 @@ from kumiki.rule import Orientation, create_v2, inches, radians, are_vectors_par
 from kumiki.timber import (
     Timber, TimberEnd, TimberFace, TimberLongFace,
     V2, V3, Numeric, PegShape, WedgeShape, Peg, Cutting, CutTimber,
-    timber_from_directions, create_v3
+    create_timber, create_v3
 )
 from kumiki.construction import ButtJointTimberArrangement
 from kumiki.timber_shavings import are_timbers_plane_aligned

--- a/tests/joints/test_compound_joints.py
+++ b/tests/joints/test_compound_joints.py
@@ -47,7 +47,7 @@ class TestMultiCrossLapJoint:
         """Two boards in an X shape (board_0 along +X, board_1 along +Y)."""
         W, L, T = scalar(6), scalar(20), scalar(4)
         wd = self._width_dir()
-        board_0 = timber_from_directions(
+        board_0 = create_timber(
             length=L,
             size=Matrix([W, T]),
             bottom_position=create_v3(scalar(-10), scalar(0), scalar(3)),
@@ -55,7 +55,7 @@ class TestMultiCrossLapJoint:
             width_direction=wd,
             ticket="board_0",
         )
-        board_1 = timber_from_directions(
+        board_1 = create_timber(
             length=L,
             size=Matrix([W, T]),
             bottom_position=create_v3(scalar(0), scalar(-10), scalar(3)),
@@ -73,7 +73,7 @@ class TestMultiCrossLapJoint:
         """
         W, L, T = scalar(6), scalar(20), scalar(4)
         wd = self._width_dir()
-        board_0 = timber_from_directions(
+        board_0 = create_timber(
             length=L,
             size=Matrix([W, T]),
             bottom_position=create_v3(scalar(-10), scalar(0), scalar(3)),
@@ -81,7 +81,7 @@ class TestMultiCrossLapJoint:
             width_direction=wd,
             ticket="board_0",
         )
-        board_1 = timber_from_directions(
+        board_1 = create_timber(
             length=L,
             size=Matrix([W, T]),
             bottom_position=create_v3(scalar(0), scalar(-10), scalar(3)),
@@ -89,7 +89,7 @@ class TestMultiCrossLapJoint:
             width_direction=wd,
             ticket="board_1",
         )
-        board_2 = timber_from_directions(
+        board_2 = create_timber(
             length=L,
             size=Matrix([W, T]),
             bottom_position=create_v3(scalar(-10), scalar(3), scalar(3)),

--- a/tests/joints/test_corner_joints.py
+++ b/tests/joints/test_corner_joints.py
@@ -211,14 +211,14 @@ class TestMiterJoint:
     # 🐪
     def test_miter_joint_on_parallel_timbers_produces_perpendicular_cuts(self):
         """cut_plain_miter_joint (base function) accepts parallel timbers and produces end cuts perpendicular to the timber axis."""
-        timberA = timber_from_directions(
+        timberA = create_timber(
             length=scalar(100),
             size=Matrix([scalar(6), scalar(6)]),
             bottom_position=Matrix([scalar(0), scalar(0), scalar(0)]),
             length_direction=Matrix([scalar(1), scalar(0), scalar(0)]),
             width_direction=Matrix([scalar(0), scalar(1), scalar(0)]),
         )
-        timberB = timber_from_directions(
+        timberB = create_timber(
             length=scalar(100),
             size=Matrix([scalar(6), scalar(6)]),
             bottom_position=Matrix([scalar(0), scalar(0), scalar(10)]),
@@ -379,7 +379,7 @@ class TestTongueAndForkJoint:
             )
 
         tongue_non_plane = create_standard_horizontal_timber(direction='x', length=100, size=(6, 6), position=(0, 0, 0))
-        fork_non_plane = timber_from_directions(
+        fork_non_plane = create_timber(
             length=scalar(100),
             size=create_v2(6, 6),
             bottom_position=create_v3(0, 0, 0),

--- a/tests/joints/test_cross_joints.py
+++ b/tests/joints/test_cross_joints.py
@@ -59,7 +59,7 @@ class TestHouseJoint:
         housing_timber = create_standard_vertical_timber(height=200, size=(10, 10), position=(0, 0, 0))
         
         # Create housed timber (horizontal beam intersecting the post)
-        housed_timber = timber_from_directions(
+        housed_timber = create_timber(
             length=scalar(80),
             size=Matrix([scalar(6), scalar(6)]),  # 6 x 6 beam
             bottom_position=Matrix([scalar(-20), scalar(0), scalar(100)]),

--- a/tests/joints/test_free_joints.py
+++ b/tests/joints/test_free_joints.py
@@ -34,7 +34,7 @@ class TestFreeHouseJoint:
 
         # 1×1 horizontal +X housed timber; bottom at (-10, 0, 10), length 20
         # Crosses the housing at global Z=10, Y ∈ [-0.5, 0.5]
-        housed_timber = timber_from_directions(
+        housed_timber = create_timber(
             length=scalar(20),
             size=Matrix([scalar(1), scalar(1)]),
             bottom_position=create_v3(scalar(-10), scalar(0), scalar(10)),
@@ -80,7 +80,7 @@ class TestFreeHouseJoint:
 
         # 2×2 horizontal +X base timber; bottom at (-10, 0, 10), length 20
         # local x = global Y, local y = global Z, local z = global X
-        housed_timber_base = timber_from_directions(
+        housed_timber_base = create_timber(
             length=scalar(20),
             size=Matrix([scalar(2), scalar(2)]),
             bottom_position=create_v3(scalar(-10), scalar(0), scalar(10)),
@@ -132,7 +132,7 @@ class TestFreeHouseJoint:
             height=20, size=(3, 3), position=(0, 0, 0), ticket="housing"
         )
 
-        housed_timber_1 = timber_from_directions(
+        housed_timber_1 = create_timber(
             length=scalar(20),
             size=Matrix([scalar(1), scalar(1)]),
             bottom_position=create_v3(scalar(-10), scalar(0), scalar(8)),
@@ -140,7 +140,7 @@ class TestFreeHouseJoint:
             width_direction=create_v3(scalar(0), scalar(1), scalar(0)),
             ticket="housed_1",
         )
-        housed_timber_2 = timber_from_directions(
+        housed_timber_2 = create_timber(
             length=scalar(20),
             size=Matrix([scalar(1), scalar(1)]),
             bottom_position=create_v3(scalar(-10), scalar(0), scalar(12)),

--- a/tests/joints/test_splice_joints.py
+++ b/tests/joints/test_splice_joints.py
@@ -94,7 +94,7 @@ class TestSpliceJoint:
     def test_splice_joint_opposite_orientation(self):
         """Test splice joint with two aligned timbers with opposite orientations."""
         # TimberA points in +X direction
-        timberA = timber_from_directions(
+        timberA = create_timber(
             length=scalar(60),
             size=Matrix([scalar(6), scalar(6)]),
             bottom_position=Matrix([scalar(0), scalar(0), scalar(0)]),
@@ -104,7 +104,7 @@ class TestSpliceJoint:
         
         # TimberB points in -X direction (opposite orientation)
         # Bottom is at x=100, top at x=40
-        timberB = timber_from_directions(
+        timberB = create_timber(
             length=scalar(60),
             size=Matrix([scalar(6), scalar(6)]),
             bottom_position=Matrix([scalar(100), scalar(0), scalar(0)]),
@@ -133,7 +133,7 @@ class TestSpliceJoint:
     def test_splice_joint_non_aligned_timbers_raises_error(self):
         """Test that non-aligned (non-parallel) timbers raise a ValueError."""
         # Create two perpendicular timbers
-        timberA = timber_from_directions(
+        timberA = create_timber(
             length=scalar(50),
             size=Matrix([scalar(4), scalar(4)]),
             bottom_position=Matrix([scalar(0), scalar(0), scalar(0)]),
@@ -141,7 +141,7 @@ class TestSpliceJoint:
             width_direction=Matrix([scalar(0), scalar(1), scalar(0)])
         )
         
-        timberB = timber_from_directions(
+        timberB = create_timber(
             length=scalar(50),
             size=Matrix([scalar(4), scalar(4)]),
             bottom_position=Matrix([scalar(50), scalar(0), scalar(0)]),
@@ -177,7 +177,7 @@ class TestSpliceLapJoint:
         timber_size = create_v2(4, 4)
         
         # TimberA extends from x=0 to x=20
-        timberA = timber_from_directions(
+        timberA = create_timber(
             length=timber_length,
             size=timber_size,
             bottom_position=create_v3(0, 0, 0),
@@ -187,7 +187,7 @@ class TestSpliceLapJoint:
         )
         
         # TimberB extends from x=20 to x=40
-        timberB = timber_from_directions(
+        timberB = create_timber(
             length=timber_length,
             size=timber_size,
             bottom_position=create_v3(20, 0, 0),

--- a/tests/test_blueprint.py
+++ b/tests/test_blueprint.py
@@ -20,7 +20,7 @@ from kumiki.blueprint import (
     _OCP_AVAILABLE,
     _THREEMF_AVAILABLE,
 )
-from kumiki.timber import CutTimber, Frame, Peg, PegShape, Timber, timber_from_directions
+from kumiki.timber import CutTimber, Frame, Peg, PegShape, Timber, create_timber
 from kumiki.rule import Transform, create_v3, create_v2, scalar
 
 
@@ -30,7 +30,7 @@ from kumiki.rule import Transform, create_v3, create_v2, scalar
 
 def _simple_timber(name: str = "test_timber") -> Timber:
     """A small axis-aligned timber for export tests."""
-    return timber_from_directions(
+    return create_timber(
         bottom_position=create_v3(scalar(0), scalar(0), scalar(0)),
         length=scalar(2),
         size=create_v2(scalar(1), scalar(1)),
@@ -46,7 +46,7 @@ def _simple_cut_timber(name: str = "test_timber") -> CutTimber:
 
 def _simple_frame() -> Frame:
     t1 = _simple_timber("beam")
-    t2 = timber_from_directions(
+    t2 = create_timber(
         bottom_position=create_v3(scalar(0), scalar(0), scalar(0)),
         length=scalar(3),
         size=create_v2(scalar(1), scalar(1)),

--- a/tests/test_construction.py
+++ b/tests/test_construction.py
@@ -29,7 +29,7 @@ class TestTimberCreation:
         length_dir = create_v3(scalar(0), scalar(0), scalar(1))
         width_dir = create_v3(scalar(1), scalar(0), scalar(0))
         
-        timber = create_timber(position, scalar("2.5"), size, length_dir, width_dir)
+        timber = create_timber(scalar("2.5"), size, position, length_dir, width_dir)
         
         assert timber.length == scalar("2.5")
         assert timber.get_bottom_position_global()[0] == scalar(1)
@@ -615,7 +615,7 @@ class TestJoinTimbers:
         timber1 = create_standard_vertical_timber(height=3, size=(0.15, 0.15), position=(0, 0, 0))
         
         # Timber2: 3D rotation not aligned with timber1's coordinate grid
-        timber2 = timber_from_directions(
+        timber2 = create_timber(
             length=scalar(3),
             size=create_v2(scalar("0.15"), scalar("0.15")),
             bottom_position=create_v3(scalar(2), scalar(2), scalar(0)),
@@ -688,7 +688,7 @@ class TestJoinTimbers:
         # Use exact integer/rational inputs for exact SymPy results
         timber1 = create_standard_vertical_timber(height=1, size=(0.1, 0.1), position=(-0.5, 0, 0))
         
-        timber2 = timber_from_directions(
+        timber2 = create_timber(
             length=1,  # Integer
             size=create_v2(scalar(1, 10), scalar(1, 10)),  # Exact rationals
             bottom_position=create_v3(scalar(1, 2), 0, 0),   # Exact rationals
@@ -811,7 +811,7 @@ class TestJoinTimbers:
         
         # Create base timbers - all horizontal and face-aligned
         for i, pos in enumerate(positions):
-            timber = timber_from_directions(
+            timber = create_timber(
                 length=2,  # 2m long
                 size=timber_size,
                 bottom_position=pos,
@@ -823,7 +823,7 @@ class TestJoinTimbers:
         
         # Create a beam at a higher level
         beam_z = scalar(3, 2)  # 1.5m height
-        beam = timber_from_directions(
+        beam = create_timber(
             length=4,  # 4m long beam
             size=create_v2(scalar(15, 100), scalar(15, 100)),  # 15cm x 15cm
             bottom_position=create_v3(-2, 0, beam_z),
@@ -991,7 +991,7 @@ class TestJoinTimbers:
         beam_size = create_v2(inches(4), inches(4))
         
         # Left post at origin
-        post_left = timber_from_directions(
+        post_left = create_timber(
             length=post_height,
             size=post_size,
             bottom_position=create_v3(0, 0, 0),
@@ -1001,7 +1001,7 @@ class TestJoinTimbers:
         )
         
         # Right post 8" away in X direction
-        post_right = timber_from_directions(
+        post_right = create_timber(
             length=post_height,
             size=post_size,
             bottom_position=create_v3(inches(8), 0, 0),
@@ -1113,7 +1113,7 @@ class TestHelperFunctions:
     def test_timber_get_closest_oriented_face_axis_aligned(self):
         """Test Timber.get_closest_oriented_face_from_global_direction() with axis-aligned timber."""
         # Create an axis-aligned timber (standard orientation)
-        timber = timber_from_directions(
+        timber = create_timber(
             length=scalar(2),
             size=create_v2(scalar("0.2"), scalar("0.3")),  # width=0.2, height=0.3
             bottom_position=create_v3(0, 0, 0),
@@ -1161,7 +1161,7 @@ class TestHelperFunctions:
         """Test Timber.get_closest_oriented_face_from_global_direction() with rotated timber."""
         # Create a timber rotated 90 degrees around Z axis
         # length_direction stays Z-up, but width_direction becomes Y-forward
-        timber = timber_from_directions(
+        timber = create_timber(
             length=scalar(2),
             size=create_v2(scalar("0.2"), scalar("0.3")),
             bottom_position=create_v3(0, 0, 0),
@@ -1201,8 +1201,8 @@ class TestHelperFunctions:
         """Test Timber.get_closest_oriented_face_from_global_direction() with horizontal timber."""
         # Create a horizontal timber lying along X axis
         # Note: create_standard_horizontal_timber uses width_direction=[0,1,0] by default,
-        # so we need to use timber_from_directions here for width_direction=[0,0,1]
-        timber = timber_from_directions(
+        # so we need to use create_timber here for width_direction=[0,0,1]
+        timber = create_timber(
             length=scalar(3),
             size=create_v2(scalar("0.2"), scalar("0.3")),
             bottom_position=create_v3(0, 0, 0),
@@ -1241,7 +1241,7 @@ class TestHelperFunctions:
     def test_timber_get_closest_oriented_face_diagonal(self):
         """Test Timber.get_closest_oriented_face_from_global_direction() with diagonal target direction."""
         # Create an axis-aligned timber
-        timber = timber_from_directions(
+        timber = create_timber(
             length=scalar(2),
             size=create_v2(scalar("0.2"), scalar("0.3")),
             bottom_position=create_v3(0, 0, 0),
@@ -1264,7 +1264,7 @@ class TestHelperFunctions:
     def test_timber_get_face_direction(self):
         """Test Timber.get_face_direction_global() method."""
         # Create an axis-aligned timber
-        timber = timber_from_directions(
+        timber = create_timber(
             length=scalar(2),
             size=create_v2(scalar("0.2"), scalar("0.3")),
             bottom_position=create_v3(0, 0, 0),
@@ -1296,7 +1296,7 @@ class TestHelperFunctions:
     def test_timber_get_face_direction_for_ends(self):
         """Test using Timber.get_face_direction_global() for timber ends."""
         # Create a timber
-        timber = timber_from_directions(
+        timber = create_timber(
             length=scalar(2),
             size=create_v2(scalar("0.2"), scalar("0.3")),
             bottom_position=create_v3(0, 0, 0),
@@ -1315,7 +1315,7 @@ class TestHelperFunctions:
     def test_timber_get_face_direction_with_timber_reference_end(self):
         """Test that Timber.get_face_direction_global() accepts TimberEnd."""
         # Create a timber
-        timber = timber_from_directions(
+        timber = create_timber(
             length=scalar(2),
             size=create_v2(scalar("0.2"), scalar("0.3")),
             bottom_position=create_v3(0, 0, 0),
@@ -1338,7 +1338,7 @@ class TestHelperFunctions:
     def test_timber_get_size_in_face_normal_axis_with_timber_reference_end(self):
         """Test that Timber.get_size_in_face_normal_axis() accepts TimberEnd."""
         # Create a timber
-        timber = timber_from_directions(
+        timber = create_timber(
             length=scalar(2),
             size=create_v2(scalar("0.2"), scalar("0.3")),
             bottom_position=create_v3(0, 0, 0),
@@ -1424,7 +1424,7 @@ class TestHelperFunctions:
         from kumiki import StickoutReference, join_face_aligned_on_face_aligned_timbers, TimberFace  # ty: ignore[deprecated]
         
         # Create two parallel horizontal posts 2.0 meters apart
-        post1 = timber_from_directions(
+        post1 = create_timber(
             length=scalar(3),
             size=create_v2(scalar("0.2"), scalar("0.2")),
             bottom_position=create_v3(0, 0, 0),
@@ -1432,7 +1432,7 @@ class TestHelperFunctions:
             width_direction=create_v3(0, 0, 1)     # Up
         )
         
-        post2 = timber_from_directions(
+        post2 = create_timber(
             length=scalar(3),
             size=create_v2(scalar("0.2"), scalar("0.2")),
             bottom_position=create_v3(0, 2, 0),  # 2m north
@@ -1460,7 +1460,7 @@ class TestHelperFunctions:
         from kumiki import StickoutReference, join_face_aligned_on_face_aligned_timbers, TimberFace  # ty: ignore[deprecated]
         
         # Create two parallel horizontal posts 2.0 meters apart
-        post1 = timber_from_directions(
+        post1 = create_timber(
             length=scalar(3),
             size=create_v2(scalar("0.2"), scalar("0.2")),
             bottom_position=create_v3(0, 0, 0),
@@ -1468,7 +1468,7 @@ class TestHelperFunctions:
             width_direction=create_v3(0, 0, 1)     # Up
         )
         
-        post2 = timber_from_directions(
+        post2 = create_timber(
             length=scalar(3),
             size=create_v2(scalar("0.2"), scalar("0.2")),
             bottom_position=create_v3(0, 2, 0),  # 2m north
@@ -1536,7 +1536,7 @@ class TestTimberFootprintOrientation:
         ]
         
         for description, bottom_pos, length_dir, width_dir, length, expected_inside, expected_outside in test_cases:
-            timber = timber_from_directions(
+            timber = create_timber(
                 length=length,
                 size=create_v2(scalar("0.2"), scalar("0.3")),
                 bottom_position=bottom_pos,
@@ -1563,7 +1563,7 @@ class TestTimberFootprintOrientation:
         footprint = Footprint(tuple(corners))
         
         # Diagonal timber from (1,1) going toward (9,9), but oriented so width points inward
-        timber = timber_from_directions(
+        timber = create_timber(
             length=scalar("11.31"),  # ~8*sqrt(2)
             size=create_v2(scalar("0.2"), scalar("0.3")),
             bottom_position=create_v3(1, 1, 0),
@@ -1618,7 +1618,7 @@ class TestSplitTimber:
     def test_split_timber_horizontal(self, symbolic_mode):
         """Test splitting a horizontal timber"""
         # Create a horizontal timber along X axis
-        timber = timber_from_directions(
+        timber = create_timber(
             length=scalar(20),
             size=create_v2(scalar(6), scalar(4)),
             bottom_position=create_v3(scalar(5), scalar(10), scalar(2)),
@@ -1642,7 +1642,7 @@ class TestSplitTimber:
         # Create a diagonal timber at 45 degrees
         length_dir = normalize_vector(create_v3(scalar(1), scalar(1), scalar(0)))
         
-        timber = timber_from_directions(
+        timber = create_timber(
             length=scalar(10),
             size=create_v2(scalar(4), scalar(4)),
             bottom_position=create_v3(scalar(0), scalar(0), scalar(0)),
@@ -1671,7 +1671,7 @@ class TestSplitTimber:
     def test_split_timber_with_rational(self, symbolic_mode):
         """Test splitting with exact rational arithmetic"""
         # Create a timber with rational values
-        timber = timber_from_directions(
+        timber = create_timber(
             length=scalar(10, 1),
             size=create_v2(scalar(4, 1), scalar(4, 1)),
             bottom_position=create_v3(scalar(0), scalar(0), scalar(0)),
@@ -1690,7 +1690,7 @@ class TestSplitTimber:
     
     def test_split_timber_invalid_distance(self):
         """Test that invalid split distances raise assertions"""
-        timber = timber_from_directions(
+        timber = create_timber(
             length=scalar(10),
             size=create_v2(scalar(4), scalar(4)),
             bottom_position=create_v3(scalar(0), scalar(0), scalar(0)),
@@ -1729,7 +1729,7 @@ class TestSplitTimber:
     def test_split_timber_preserves_orientation(self):
         """Test that both resulting timbers preserve the original orientation"""
         # Create a timber with non-standard orientation
-        timber = timber_from_directions(
+        timber = create_timber(
             length=scalar(15),
             size=create_v2(scalar(6), scalar(8)),
             bottom_position=create_v3(scalar(1), scalar(2), scalar(3)),
@@ -1757,8 +1757,8 @@ class TestSplitTimber:
 
 def test_join_plane_aligned_on_place_aligned_timbers():
     # Let's use create_timber
-    t1 = create_timber(create_v3(0, 0, 0), scalar(100), create_v2(10, 10), length_direction=create_v3(0, 1, 0), width_direction=create_v3(0, 0, 1))
-    t2 = create_timber(create_v3(50, -50, 0), scalar(100), create_v2(10, 10), length_direction=create_v3(1, 0, 0), width_direction=create_v3(0, 0, 1))
+    t1 = create_timber(scalar(100), create_v2(10, 10), create_v3(0, 0, 0), length_direction=create_v3(0, 1, 0), width_direction=create_v3(0, 0, 1))
+    t2 = create_timber(scalar(100), create_v2(10, 10), create_v3(50, -50, 0), length_direction=create_v3(1, 0, 0), width_direction=create_v3(0, 0, 1))
     
     stickout = Stickout(stickout1=scalar(0), stickout2=scalar(0))
     size = create_v2(10, 10)
@@ -1777,7 +1777,7 @@ class TestAttachFaceAlignedTimber:
     def _make_post(self):
         # Vertical 2x2 post from the origin, length 10, length +Z, width +X.
         # => RIGHT face normal +X, FRONT face normal +Y, length +Z.
-        return timber_from_directions(
+        return create_timber(
             length=scalar(10),
             size=create_v2(scalar(2), scalar(2)),
             bottom_position=create_v3(0, 0, 0),
@@ -1946,7 +1946,7 @@ class TestAttachFaceAlignedTimber:
 
     def _make_far_post(self):
         # A second vertical 2x2 post with its centerline at x=10: faces at x=9 and x=11.
-        return timber_from_directions(
+        return create_timber(
             length=scalar(10),
             size=create_v2(scalar(2), scalar(2)),
             bottom_position=create_v3(10, 0, 0),
@@ -2025,7 +2025,7 @@ class TestAttachFaceAlignedTimber:
         # a target post rotated 45 degrees about its own axis: INSIDE/OUTSIDE reference the
         # near/far corner edges of its projected silhouette rather than its (diagonal) faces
         post = self._make_post()
-        rotated_post = timber_from_directions(
+        rotated_post = create_timber(
             length=scalar(10),
             size=create_v2(scalar(2), scalar(2)),
             bottom_position=create_v3(10, 0, 0),
@@ -2053,7 +2053,7 @@ class TestAttachFaceAlignedTimber:
         # projects to a single *point* on the attachment plane, which is dropped perpendicularly
         # onto the attached timber's length axis
         post = self._make_post()
-        cross_beam = timber_from_directions(
+        cross_beam = create_timber(
             length=scalar(10),
             size=create_v2(scalar(2), scalar(2)),
             bottom_position=create_v3(7, -5, 3),  # centerline: x=7, z=3, running along +Y
@@ -2095,7 +2095,7 @@ class TestAttachPlaneAlignedTimber:
     """Tests for attach_plane_aligned_timber (the angled generalization)."""
 
     def _make_post(self):
-        return timber_from_directions(
+        return create_timber(
             length=scalar(10),
             size=create_v2(scalar(2), scalar(2)),
             bottom_position=create_v3(0, 0, 0),
@@ -2173,7 +2173,7 @@ class TestAttachPlaneAlignedTimber:
         # the far-end centerline point must land exactly on that centerline (projected onto the
         # attachment plane)
         post = self._make_post()
-        far_post = timber_from_directions(
+        far_post = create_timber(
             length=scalar(10),
             size=create_v2(scalar(2), scalar(2)),
             bottom_position=create_v3(10, 0, 0),
@@ -2200,7 +2200,7 @@ class TestAttachPlaneAlignedTimber:
         # moves as the length grows): the far-end centerline point must still land exactly on
         # the target centerline height
         post = self._make_post()
-        beam_above = timber_from_directions(
+        beam_above = create_timber(
             length=scalar(40),
             size=create_v2(scalar(2), scalar(2)),
             bottom_position=create_v3(0, 0, 15),
@@ -2226,7 +2226,7 @@ class TestAttachTimber:
     """Test for attach_timber (arbitrary direction, no face/plane alignment)."""
 
     def test_direction_position_and_lateral_offset(self, symbolic_mode):
-        post = timber_from_directions(
+        post = create_timber(
             length=scalar(10),
             size=create_v2(scalar(2), scalar(2)),
             bottom_position=create_v3(0, 0, 0),

--- a/tests/test_measuring.py
+++ b/tests/test_measuring.py
@@ -4,7 +4,7 @@ Tests for the measuring module (geometric primitives).
 
 import pytest
 from kumiki.measuring import *
-from kumiki.timber import timber_from_directions, TimberFace, TimberLongEdge, TimberEdge, TimberCenterline, TimberCorner
+from kumiki.timber import create_timber, TimberFace, TimberLongEdge, TimberEdge, TimberCenterline, TimberCorner
 from kumiki.rule import create_v3, create_v2, Transform, Orientation, scalar
 from sympy import Matrix
 
@@ -14,7 +14,7 @@ class TestGetPointOnFace:
 
     def test_get_point_on_right_face(self, symbolic_mode):
         """Test getting a point on the RIGHT face of a vertical timber"""
-        timber = timber_from_directions(
+        timber = create_timber(
             length=scalar(100),
             size=create_v2(10, 10),
             bottom_position=create_v3(0, 0, 0),
@@ -31,7 +31,7 @@ class TestGetPointOnFace:
 
     def test_get_point_on_top_face(self, symbolic_mode):
         """Test getting a point on the TOP face of a vertical timber"""
-        timber = timber_from_directions(
+        timber = create_timber(
             length=scalar(100),
             size=create_v2(10, 10),
             bottom_position=create_v3(0, 0, 0),
@@ -52,7 +52,7 @@ class TestMeasureOntoFace:
     
     def test_project_point_on_face_surface(self):
         """Test projecting a point that's exactly on the face surface"""
-        timber = timber_from_directions(
+        timber = create_timber(
             length=scalar(100),
             size=create_v2(10, 10),
             bottom_position=create_v3(0, 0, 0),
@@ -69,7 +69,7 @@ class TestMeasureOntoFace:
     
     def test_project_point_inside_timber(self, symbolic_mode):
         """Test projecting a point inside the timber"""
-        timber = timber_from_directions(
+        timber = create_timber(
             length=scalar(100),
             size=create_v2(10, 10),
             bottom_position=create_v3(0, 0, 0),
@@ -86,7 +86,7 @@ class TestMeasureOntoFace:
     
     def test_project_point_outside_timber(self, symbolic_mode):
         """Test projecting a point outside the timber"""
-        timber = timber_from_directions(
+        timber = create_timber(
             length=scalar(100),
             size=create_v2(10, 10),
             bottom_position=create_v3(0, 0, 0),
@@ -103,7 +103,7 @@ class TestMeasureOntoFace:
     
     def test_project_point_on_left_face(self, symbolic_mode):
         """Test projection onto LEFT face"""
-        timber = timber_from_directions(
+        timber = create_timber(
             length=scalar(100),
             size=create_v2(10, 10),
             bottom_position=create_v3(0, 0, 0),
@@ -121,7 +121,7 @@ class TestMeasureOntoFace:
     
     def test_project_point_on_front_face(self, symbolic_mode):
         """Test projection onto FRONT face"""
-        timber = timber_from_directions(
+        timber = create_timber(
             length=scalar(100),
             size=create_v2(10, 20),  # 10" wide (X), 20" height (Y)
             bottom_position=create_v3(0, 0, 0),
@@ -139,7 +139,7 @@ class TestMeasureOntoFace:
     
     def test_project_point_with_offset_timber(self, symbolic_mode):
         """Test projection on a timber not centered at origin"""
-        timber = timber_from_directions(
+        timber = create_timber(
             length=scalar(48),
             size=create_v2(6, 6),
             bottom_position=create_v3(10, 20, 5),  # Offset position
@@ -279,7 +279,7 @@ class TestGetPointOnFeature:
     
     def test_get_point_on_point_feature(self):
         """Test getting point from Point feature"""
-        timber = timber_from_directions(
+        timber = create_timber(
             length=scalar(100),
             size=create_v2(10, 10),
             bottom_position=create_v3(0, 0, 0),
@@ -295,7 +295,7 @@ class TestGetPointOnFeature:
     
     def test_get_point_on_plane_feature(self):
         """Test getting point from Plane feature"""
-        timber = timber_from_directions(
+        timber = create_timber(
             length=scalar(100),
             size=create_v2(10, 10),
             bottom_position=create_v3(0, 0, 0),
@@ -315,7 +315,7 @@ class TestMeasureFromFace:
     
     def test_locate_zero_distance_from_face(self, symbolic_mode):
         """Test measuring zero distance creates plane at face surface"""
-        timber = timber_from_directions(
+        timber = create_timber(
             length=scalar(100),
             size=create_v2(10, 10),
             bottom_position=create_v3(0, 0, 0),
@@ -334,7 +334,7 @@ class TestMeasureFromFace:
     
     def test_locate_positive_distance_from_face(self, symbolic_mode):
         """Test measuring positive distance INTO the face"""
-        timber = timber_from_directions(
+        timber = create_timber(
             length=scalar(100),
             size=create_v2(10, 10),
             bottom_position=create_v3(0, 0, 0),
@@ -354,7 +354,7 @@ class TestMarkFromFace:
     
     def test_mark_onto_face_round_trip(self, symbolic_mode):
         """Test that mark_distance_from_face_in_normal_direction is inverse of locate_into_face"""
-        timber = timber_from_directions(
+        timber = create_timber(
             length=scalar(100),
             size=create_v2(10, 10),
             bottom_position=create_v3(0, 0, 0),
@@ -370,7 +370,7 @@ class TestMarkFromFace:
     
     def test_mark_point_from_face(self, symbolic_mode):
         """Test marking a point feature from a face"""
-        timber = timber_from_directions(
+        timber = create_timber(
             length=scalar(100),
             size=create_v2(10, 10),
             bottom_position=create_v3(0, 0, 0),
@@ -390,7 +390,7 @@ class TestMeasureFace:
     
     def test_locate_face_right(self, symbolic_mode):
         """Test measuring the RIGHT face of a vertical timber"""
-        timber = timber_from_directions(
+        timber = create_timber(
             length=scalar(100),
             size=create_v2(10, 20),  # 10" wide (X), 20" height (Y)
             bottom_position=create_v3(0, 0, 0),
@@ -412,7 +412,7 @@ class TestMeasureFace:
     
     def test_locate_face_front(self, symbolic_mode):
         """Test measuring the FRONT face of a vertical timber"""
-        timber = timber_from_directions(
+        timber = create_timber(
             length=scalar(100),
             size=create_v2(10, 20),
             bottom_position=create_v3(0, 0, 0),
@@ -436,7 +436,7 @@ class TestMeasureLongEdge:
     
     def test_locate_long_edge_right_front(self, symbolic_mode):
         """Test measuring the RIGHT_FRONT edge of a vertical timber"""
-        timber = timber_from_directions(
+        timber = create_timber(
             length=scalar(100),
             size=create_v2(10, 20),  # 10" wide (X), 20" height (Y)
             bottom_position=create_v3(0, 0, 0),
@@ -458,7 +458,7 @@ class TestMeasureLongEdge:
     
     def test_locate_long_edge_left_back(self, symbolic_mode):
         """Test measuring the LEFT_BACK edge of a vertical timber"""
-        timber = timber_from_directions(
+        timber = create_timber(
             length=scalar(100),
             size=create_v2(10, 20),
             bottom_position=create_v3(0, 0, 0),
@@ -479,7 +479,7 @@ class TestMeasureLongEdge:
     def test_locate_long_edge_horizontal_timber(self, symbolic_mode):
         """Test measuring edge on a horizontal timber"""
         # Horizontal timber pointing in +X direction
-        timber = timber_from_directions(
+        timber = create_timber(
             length=scalar(100),
             size=create_v2(4, 6),
             bottom_position=create_v3(0, 0, 0),
@@ -508,7 +508,7 @@ class TestMeasureShortEdge:
         front-right corner (5, 10, 0). Direction = FRONT = +Y.
         Point = BOT_BACK_RIGHT corner = (5, -10, 0).
         """
-        timber = timber_from_directions(
+        timber = create_timber(
             length=scalar(100),
             size=create_v2(10, 20),
             bottom_position=create_v3(0, 0, 0),
@@ -530,7 +530,7 @@ class TestMeasureShortEdge:
         right-front corner (5, 10, 100). Direction = RIGHT = +X.
         Point = TOP_FRONT_LEFT corner = (-5, 10, 100).
         """
-        timber = timber_from_directions(
+        timber = create_timber(
             length=scalar(100),
             size=create_v2(10, 20),
             bottom_position=create_v3(0, 0, 0),
@@ -551,7 +551,7 @@ class TestMeasurePlaneFromEdgeInDirection:
 
     def test_plane_from_centerline_offset_in_x(self, symbolic_mode):
         """Plane through centerline offset 3 in +X should have normal +X and point at (3, 0, 50)."""
-        timber = timber_from_directions(
+        timber = create_timber(
             length=scalar(100),
             size=create_v2(10, 20),
             bottom_position=create_v3(0, 0, 0),
@@ -574,7 +574,7 @@ class TestMeasureCenterLine:
     
     def test_locate_centerline_vertical(self, symbolic_mode):
         """Test measuring the center line of a vertical timber"""
-        timber = timber_from_directions(
+        timber = create_timber(
             length=scalar(100),
             size=create_v2(10, 20),
             bottom_position=create_v3(0, 0, 0),
@@ -596,7 +596,7 @@ class TestMeasureCenterLine:
     
     def test_locate_centerline_horizontal(self, symbolic_mode):
         """Test measuring the center line of a horizontal timber"""
-        timber = timber_from_directions(
+        timber = create_timber(
             length=scalar(48),
             size=create_v2(4, 6),
             bottom_position=create_v3(10, 20, 5),  # Offset position
@@ -620,7 +620,7 @@ class TestMeasureCenterLine:
         from kumiki.rule import safe_normalize_vector as normalize_vector
         
         direction = normalize_vector(create_v3(1, 1, 1))  # Diagonal
-        timber = timber_from_directions(
+        timber = create_timber(
             length=scalar(60),
             size=create_v2(4, 4),
             bottom_position=create_v3(0, 0, 0),
@@ -643,7 +643,7 @@ class TestDistanceFromPointIntoFaceMark:
     
     def test_mark_from_face_center(self):
         """Test marking a line from face center going into timber"""
-        timber = timber_from_directions(
+        timber = create_timber(
             length=scalar(100),
             size=create_v2(10, 10),
             bottom_position=create_v3(0, 0, 0),
@@ -667,7 +667,7 @@ class TestDistanceFromPointIntoFaceMark:
     
     def test_mark_from_custom_point(self):
         """Test marking a line from a custom point going into timber"""
-        timber = timber_from_directions(
+        timber = create_timber(
             length=scalar(100),
             size=create_v2(10, 10),
             bottom_position=create_v3(0, 0, 0),
@@ -695,7 +695,7 @@ class TestDistanceFromLongEdgeOnFaceMark:
     
     def test_mark_on_right_face(self):
         """Test marking a line parallel to edge on RIGHT face"""
-        timber = timber_from_directions(
+        timber = create_timber(
             length=scalar(100),
             size=create_v2(10, 10),
             bottom_position=create_v3(0, 0, 0),
@@ -720,7 +720,7 @@ class TestDistanceFromLongEdgeOnFaceMark:
     
     def test_mark_on_front_face(self):
         """Test marking a line parallel to edge on FRONT face"""
-        timber = timber_from_directions(
+        timber = create_timber(
             length=scalar(100),
             size=create_v2(10, 10),
             bottom_position=create_v3(0, 0, 0),
@@ -749,7 +749,7 @@ class TestMeasureOntoCenterline:
     
     def test_locate_plane_onto_centerline(self, symbolic_mode):
         """Test measuring a plane intersection onto centerline"""
-        timber = timber_from_directions(
+        timber = create_timber(
             length=scalar(100),
             size=create_v2(10, 10),
             bottom_position=create_v3(0, 0, 0),
@@ -780,7 +780,7 @@ class TestMeasureOntoCenterline:
     
     def test_locate_line_onto_centerline(self, symbolic_mode):
         """Test measuring closest point between a line and centerline"""
-        timber = timber_from_directions(
+        timber = create_timber(
             length=scalar(100),
             size=create_v2(10, 10),
             bottom_position=create_v3(0, 0, 0),
@@ -815,7 +815,7 @@ class TestMarkPlaneFromEdgeInDirection:
 
     def test_round_trip_with_measure(self, symbolic_mode):
         """measure then mark should recover the original direction and distance."""
-        timber = timber_from_directions(
+        timber = create_timber(
             length=scalar(100),
             size=create_v2(10, 20),
             bottom_position=create_v3(0, 0, 0),
@@ -836,7 +836,7 @@ class TestMarkPlaneFromEdgeInDirection:
         from kumiki.rule import safe_normalize_vector as normalize_vector, zero_test
         from sympy import simplify
 
-        timber = timber_from_directions(
+        timber = create_timber(
             length=scalar(60),
             size=create_v2(4, 6),
             bottom_position=create_v3(10, 20, 5),
@@ -862,7 +862,7 @@ class TestPointFromCornerInFaceDirection:
 
     def test_valid_and_invalid_face_direction(self, symbolic_mode):
         """TOP is valid from BOT_RIGHT_FRONT (points inward); RIGHT is invalid (points outward)."""
-        timber = timber_from_directions(
+        timber = create_timber(
             length=scalar(100),
             size=create_v2(10, 20),
             bottom_position=create_v3(0, 0, 0),
@@ -898,7 +898,7 @@ class TestMarkDistanceFromCornerAlongEdge:
     def test_intersect_plane_with_centerline(self, symbolic_mode):
         """Plane at z=30 intersects the centerline of a 100-long vertical timber.
         From BOTTOM (z=0), distance should be 30."""
-        timber = timber_from_directions(
+        timber = create_timber(
             length=scalar(100),
             size=create_v2(10, 20),
             bottom_position=create_v3(0, 0, 0),
@@ -919,7 +919,7 @@ class TestMarkDistanceFromCornerAlongEdge:
     def test_closest_point_on_centerline_to_perpendicular_line(self, symbolic_mode):
         """A horizontal line at z=40 perpendicular to a vertical timber's centerline.
         The closest point on the centerline is at z=40, so distance from BOTTOM = 40."""
-        timber = timber_from_directions(
+        timber = create_timber(
             length=scalar(100),
             size=create_v2(10, 20),
             bottom_position=create_v3(0, 0, 0),

--- a/tests/test_patternbook.py
+++ b/tests/test_patternbook.py
@@ -4,7 +4,7 @@ Tests for the PatternBook module
 
 import pytest
 from kumiki.rule import V3, create_v3, create_v2, inches, Transform, Orientation, scalar
-from kumiki.timber import timber_from_directions, Frame, CutTimber, CSGAccessory
+from kumiki.timber import create_timber, Frame, CutTimber, CSGAccessory
 from kumiki.cutcsg import RectangularPrism
 from kumiki.patternbook import PatternMetadata, PatternBook, PatternLambda
 
@@ -57,7 +57,7 @@ def test_pattern_book_creation_with_frames():
     """Test creating a PatternBook with frame patterns."""
     # Create a simple pattern function
     def make_simple_frame(center):
-        timber = timber_from_directions(
+        timber = create_timber(
             length=inches(24),
             size=create_v2(inches(2), inches(4)),
             bottom_position=center,
@@ -99,7 +99,7 @@ def test_pattern_book_creation_with_csg():
 def test_pattern_book_duplicate_names():
     """Test that duplicate pattern names raise ValueError."""
     def make_frame1(center):
-        timber = timber_from_directions(
+        timber = create_timber(
             length=inches(24),
             size=create_v2(inches(2), inches(4)),
             bottom_position=center,
@@ -121,7 +121,7 @@ def test_pattern_book_duplicate_names():
 def test_raise_pattern():
     """Test raising a single pattern."""
     def make_frame(center: V3) -> Frame:
-        timber = timber_from_directions(
+        timber = create_timber(
             length=inches(24),
             size=create_v2(inches(2), inches(4)),
             bottom_position=center,
@@ -159,7 +159,7 @@ def test_raise_pattern_group_frames():
     """Test raising a group of frame patterns."""
     def make_frame(name):
         def _make(center):
-            timber = timber_from_directions(
+            timber = create_timber(
                 length=inches(24),
                 size=create_v2(inches(2), inches(4)),
                 bottom_position=center,
@@ -252,7 +252,7 @@ def test_raise_patternbook_as_frame_combines_frame_and_csg_patterns():
     """Mixed frame/CSG patternbooks should combine into one viewable Frame."""
 
     def make_frame(center: V3) -> Frame:
-        timber = timber_from_directions(
+        timber = create_timber(
             length=inches(24),
             size=create_v2(inches(2), inches(4)),
             bottom_position=center,
@@ -288,7 +288,7 @@ def test_raise_patternbook_as_frame_combines_frame_and_csg_patterns():
 def test_raise_pattern_group_mixed_types():
     """Test that mixing frame and CSG patterns in a group raises ValueError."""
     def make_frame(center):
-        timber = timber_from_directions(
+        timber = create_timber(
             length=inches(24),
             size=create_v2(inches(2), inches(4)),
             bottom_position=center,

--- a/tests/test_timber.py
+++ b/tests/test_timber.py
@@ -220,7 +220,7 @@ class TestTimber:
         length_dir = create_v3(scalar(0), scalar(0), scalar(1))  # Use exact integers
         width_dir = create_v3(1, 0, 0)   # Use exact integers
         
-        timber = timber_from_directions(length, size, position, length_dir, width_dir)
+        timber = create_timber(length, size, position, length_dir, width_dir)
         
         assert timber.length == 3
         assert timber.size.shape == (2, 1)
@@ -258,7 +258,7 @@ class TestTimber:
         input_length_dir = create_v3(scalar(0), scalar(0), scalar(1))  # Up - exact integers
         input_width_dir = create_v3(1, 0, 0)    # East - exact integers
         
-        timber = timber_from_directions(
+        timber = create_timber(
             length=2,  # Use exact integer
             size=create_v2(scalar(1, 10), scalar(1, 10)),  # 0.1 as exact rational
             bottom_position=create_v3(scalar(0), scalar(0), scalar(0)),  # Use exact integers
@@ -291,7 +291,7 @@ class TestTimber:
         input_length_dir = create_v3(scalar(0), scalar(1), scalar(0))  # North - exact integers
         input_width_dir = create_v3(scalar(0), scalar(0), scalar(1))    # Up - exact integers
         
-        timber = timber_from_directions(
+        timber = create_timber(
             length=3,  # Use exact integer
             size=create_v2(scalar(1, 10), scalar(1, 10)),  # 0.1 as exact rational
             bottom_position=create_v3(scalar(0), scalar(0), scalar(0)),  # Use exact integers
@@ -320,7 +320,7 @@ class TestTimber:
     
     def test_orientation_directions_are_orthonormal(self):
         """Test that the computed direction vectors form an orthonormal basis."""
-        timber = timber_from_directions(
+        timber = create_timber(
             length=scalar(1),
             size=create_v2(scalar("0.1"), scalar("0.1")),
             bottom_position=create_v3(scalar(0), scalar(0), scalar(0)),
@@ -348,7 +348,7 @@ class TestTimber:
         input_length_dir = create_v3(scalar(0), scalar(0), scalar(5))  # Up, but length 5
         input_width_dir = create_v3(scalar(3), scalar(0), scalar(0))    # East, but length 3
         
-        timber = timber_from_directions(
+        timber = create_timber(
             length=scalar(1),
             size=create_v2(scalar("0.1"), scalar("0.1")),
             bottom_position=create_v3(scalar(0), scalar(0), scalar(0)),
@@ -371,7 +371,7 @@ class TestTimber:
     
     def test_get_position_on_centerline_from_bottom_global(self, symbolic_mode):
         """Test the get_centerline_position_from_bottom method."""
-        timber = timber_from_directions(
+        timber = create_timber(
             length=scalar(5),
             size=create_v2(scalar("0.2"), scalar("0.3")),
             bottom_position=create_v3(scalar(1), scalar(2), scalar(3)),
@@ -405,7 +405,7 @@ class TestTimber:
     
     def test_get_position_on_centerline_from_bottom_global(self, symbolic_mode):
         """Test get_centerline_position_from_bottom method."""
-        timber = timber_from_directions(
+        timber = create_timber(
             length=scalar(10),
             size=create_v2(scalar("0.2"), scalar("0.3")),
             bottom_position=create_v3(scalar(1), scalar(2), scalar(3)),
@@ -433,7 +433,7 @@ class TestTimber:
     
     def test_get_position_on_centerline_from_top_global(self, symbolic_mode):
         """Test get_centerline_position_from_top method."""
-        timber = timber_from_directions(
+        timber = create_timber(
             length=scalar(10),
             size=create_v2(scalar("0.2"), scalar("0.3")),
             bottom_position=create_v3(scalar(1), scalar(2), scalar(3)),
@@ -463,7 +463,7 @@ class TestTimber:
         """Test get_size_in_face_normal_axis method returns correct dimensions for each face."""
         # Create a timber with distinct dimensions:
         # length = 10, width (size[0]) = 0.2, height (size[1]) = 0.3
-        timber = timber_from_directions(
+        timber = create_timber(
             length=scalar(10),
             size=create_v2(scalar("0.2"), scalar("0.3")),
             bottom_position=create_v3(scalar(0), scalar(0), scalar(0)),
@@ -663,7 +663,7 @@ class TestGetCornerPositionGlobal:
 
     def test_bot_right_front_vertical_timber(self, symbolic_mode):
         """BOT_RIGHT_FRONT corner of a 10x20x100 vertical timber at origin = (5, 10, 0)."""
-        timber = timber_from_directions(
+        timber = create_timber(
             length=scalar(100),
             size=create_v2(10, 20),
             bottom_position=create_v3(0, 0, 0),
@@ -689,7 +689,7 @@ class TestCutTimber:
         length_direction = Matrix([scalar(0), scalar(0), scalar(1)])
         width_direction = Matrix([scalar(1), scalar(0), scalar(0)])
         
-        timber = timber_from_directions(length, size, bottom_position, length_direction, width_direction, ticket='test_timber')
+        timber = create_timber(length, size, bottom_position, length_direction, width_direction, ticket='test_timber')
         cut_timber = CutTimber(timber)
         
         # Get the CSG
@@ -722,7 +722,7 @@ class TestCutTimber:
         length_direction = Matrix([scalar(0), scalar(0), scalar(1)])
         width_direction = Matrix([scalar(1), scalar(0), scalar(0)])
         
-        timber = timber_from_directions(length, size, bottom_position, length_direction, width_direction)
+        timber = create_timber(length, size, bottom_position, length_direction, width_direction)
         cut_timber = CutTimber(timber)
         
         csg = cut_timber._extended_timber_without_cuts_csg_local()
@@ -743,7 +743,7 @@ class TestCutTimber:
         length_direction = Matrix([scalar(1), scalar(0), scalar(0)])  # Along X
         width_direction = Matrix([scalar(0), scalar(1), scalar(0)])
         
-        timber = timber_from_directions(length, size, bottom_position, length_direction, width_direction)
+        timber = create_timber(length, size, bottom_position, length_direction, width_direction)
         cut_timber = CutTimber(timber)
         
         csg = cut_timber._extended_timber_without_cuts_csg_local()
@@ -768,7 +768,7 @@ class TestCutTimber:
         length_direction = Matrix([scalar(0), scalar(0), scalar(1)])
         width_direction = Matrix([scalar(1), scalar(0), scalar(0)])
         
-        timber = timber_from_directions(length, size, bottom_position, length_direction, width_direction)
+        timber = create_timber(length, size, bottom_position, length_direction, width_direction)
         cut_timber = CutTimber(timber, cuts=[])
         
         # Get the CSG with cuts applied (should be same as without cuts since there are none)
@@ -789,7 +789,7 @@ class TestCutTimber:
         length_direction = Matrix([scalar(0), scalar(0), scalar(1)])
         width_direction = Matrix([scalar(1), scalar(0), scalar(0)])
         
-        timber = timber_from_directions(length, size, bottom_position, length_direction, width_direction)
+        timber = create_timber(length, size, bottom_position, length_direction, width_direction)
         
         # Add a cut (a simple half-plane cut at z=50 in local coordinates)
         from kumiki.cutcsg import HalfSpace
@@ -824,7 +824,7 @@ class TestCutTimber:
         length_direction = Matrix([scalar(0), scalar(0), scalar(1)])
         width_direction = Matrix([scalar(1), scalar(0), scalar(0)])
         
-        timber = timber_from_directions(length, size, bottom_position, length_direction, width_direction)
+        timber = create_timber(length, size, bottom_position, length_direction, width_direction)
         
         # Add two cuts
         from kumiki.cutcsg import HalfSpace
@@ -866,7 +866,7 @@ class TestCutTimber:
         length_direction = Matrix([scalar(0), scalar(0), scalar(1)])
         width_direction = Matrix([scalar(1), scalar(0), scalar(0)])
         
-        timber = timber_from_directions(length, size, bottom_position, length_direction, width_direction)
+        timber = create_timber(length, size, bottom_position, length_direction, width_direction)
         
         # Add an end cut at the top
         from kumiki.cutcsg import HalfSpace

--- a/tests/test_timber_shavings.py
+++ b/tests/test_timber_shavings.py
@@ -23,7 +23,7 @@ class TestFindOpposingFaceOnAnotherTimber:
         timber_size = create_v2(inches(4), inches(6))
         
         # Timber A pointing east (along X-axis)
-        timber_a = timber_from_directions(
+        timber_a = create_timber(
             length=inches(36),
             size=timber_size,
             bottom_position=create_v3(0, 0, 0),
@@ -41,7 +41,7 @@ class TestFindOpposingFaceOnAnotherTimber:
         # - BACK face points Down: (0, 0, -1)
         
         # Timber B pointing east, offset in Y direction (north)
-        timber_b = timber_from_directions(
+        timber_b = create_timber(
             length=inches(36),
             size=timber_size,
             bottom_position=create_v3(0, inches(10), 0),  # 10 inches north
@@ -78,7 +78,7 @@ class TestFindOpposingFaceOnAnotherTimber:
         timber_size = create_v2(inches(4), inches(6))
         
         # Timber A pointing along X-axis (East)
-        timber_a = timber_from_directions(
+        timber_a = create_timber(
             length=inches(36),
             size=timber_size,
             bottom_position=create_v3(0, 0, 0),
@@ -102,7 +102,7 @@ class TestFindOpposingFaceOnAnotherTimber:
         # width_direction perpendicular to length in XY plane: (-sin(30°), cos(30°), 0)
         width_dir_b = create_v3(-sin(angle), cos(angle), 0)
         
-        timber_b = timber_from_directions(
+        timber_b = create_timber(
             length=inches(36),
             size=timber_size,
             bottom_position=create_v3(inches(20), 0, 0),
@@ -144,7 +144,7 @@ class TestFindOpposingFaceOnAnotherTimber:
         timber_size = create_v2(inches(4), inches(6))
         
         # Timber A pointing east
-        timber_a = timber_from_directions(
+        timber_a = create_timber(
             length=inches(36),
             size=timber_size,
             bottom_position=create_v3(0, 0, 0),
@@ -155,7 +155,7 @@ class TestFindOpposingFaceOnAnotherTimber:
         
         # Timber B pointing up (perpendicular to Timber A)
         # This timber has no faces parallel to Timber A's RIGHT face
-        timber_b = timber_from_directions(
+        timber_b = create_timber(
             length=inches(36),
             size=timber_size,
             bottom_position=create_v3(inches(20), 0, 0),
@@ -177,7 +177,7 @@ class TestFindOpposingFaceOnAnotherTimber:
         from sympy import sqrt
         
         # Timber B with non-axis-aligned orientation
-        timber_b = timber_from_directions(
+        timber_b = create_timber(
             length=inches(36),
             size=timber_size,
             bottom_position=create_v3(inches(20), 0, 0),
@@ -431,7 +431,7 @@ class TestCreatePegGoingIntoFace:
     
     def setup_method(self):
         """Create a standard vertical timber for testing."""
-        self.timber = timber_from_directions(
+        self.timber = create_timber(
             length=scalar(100),
             size=create_v2(scalar(10), scalar(15)),
             bottom_position=create_v3(0, 0, 0),
@@ -539,7 +539,7 @@ class TestProjectGlobalPointOntoTimberFace:
     def test_project_onto_top_face_axis_aligned(self, symbolic_mode):
         """Test projecting a point onto the top face of an axis-aligned timber."""
         # Create a simple vertical timber
-        timber = timber_from_directions(
+        timber = create_timber(
             length=scalar(2),
             size=create_v2(scalar("0.2"), scalar("0.3")),
             bottom_position=create_v3(0, 0, 0),
@@ -559,7 +559,7 @@ class TestProjectGlobalPointOntoTimberFace:
     
     def test_project_onto_bottom_face_axis_aligned(self, symbolic_mode):
         """Test projecting a point onto the bottom face."""
-        timber = timber_from_directions(
+        timber = create_timber(
             length=scalar(2),
             size=create_v2(scalar("0.2"), scalar("0.3")),
             bottom_position=create_v3(0, 0, 0),
@@ -579,7 +579,7 @@ class TestProjectGlobalPointOntoTimberFace:
     
     def test_project_onto_right_face_axis_aligned(self, symbolic_mode):
         """Test projecting a point onto the right face."""
-        timber = timber_from_directions(
+        timber = create_timber(
             length=scalar(2),
             size=create_v2(scalar("0.2"), scalar("0.3")),
             bottom_position=create_v3(0, 0, 0),
@@ -598,7 +598,7 @@ class TestProjectGlobalPointOntoTimberFace:
     
     def test_project_onto_left_face_axis_aligned(self, symbolic_mode):
         """Test projecting a point onto the left face."""
-        timber = timber_from_directions(
+        timber = create_timber(
             length=scalar(2),
             size=create_v2(scalar("0.2"), scalar("0.3")),
             bottom_position=create_v3(0, 0, 0),
@@ -616,7 +616,7 @@ class TestProjectGlobalPointOntoTimberFace:
     
     def test_project_onto_front_face_axis_aligned(self, symbolic_mode):
         """Test projecting a point onto the front face."""
-        timber = timber_from_directions(
+        timber = create_timber(
             length=scalar(2),
             size=create_v2(scalar("0.2"), scalar("0.3")),
             bottom_position=create_v3(0, 0, 0),
@@ -634,7 +634,7 @@ class TestProjectGlobalPointOntoTimberFace:
     
     def test_project_onto_back_face_axis_aligned(self, symbolic_mode):
         """Test projecting a point onto the back face."""
-        timber = timber_from_directions(
+        timber = create_timber(
             length=scalar(2),
             size=create_v2(scalar("0.2"), scalar("0.3")),
             bottom_position=create_v3(0, 0, 0),
@@ -652,7 +652,7 @@ class TestProjectGlobalPointOntoTimberFace:
     
     def test_project_point_already_on_face(self, symbolic_mode):
         """Test that projecting a point already on the face returns the same point."""
-        timber = timber_from_directions(
+        timber = create_timber(
             length=scalar(2),
             size=create_v2(scalar("0.2"), scalar("0.3")),
             bottom_position=create_v3(0, 0, 0),
@@ -671,7 +671,7 @@ class TestProjectGlobalPointOntoTimberFace:
     def test_project_onto_rotated_timber(self, symbolic_mode):
         """Test projecting onto a face of a rotated timber."""
         # Create a timber pointing east (along X-axis)
-        timber = timber_from_directions(
+        timber = create_timber(
             length=scalar(2),
             size=create_v2(scalar("0.2"), scalar("0.3")),
             bottom_position=create_v3(0, 0, 0),
@@ -691,7 +691,7 @@ class TestProjectGlobalPointOntoTimberFace:
     
     def test_project_with_offset_bottom_position(self, symbolic_mode):
         """Test projection on a timber with non-zero bottom position."""
-        timber = timber_from_directions(
+        timber = create_timber(
             length=scalar(2),
             size=create_v2(scalar("0.2"), scalar("0.3")),
             bottom_position=create_v3(5, 10, 20),  # Offset position
@@ -709,7 +709,7 @@ class TestProjectGlobalPointOntoTimberFace:
     
     def test_project_accepts_timber_reference_end(self, symbolic_mode):
         """Test that the method accepts TimberEnd as well as TimberFace."""
-        timber = timber_from_directions(
+        timber = create_timber(
             length=scalar(2),
             size=create_v2(scalar("0.2"), scalar("0.3")),
             bottom_position=create_v3(0, 0, 0),
@@ -732,7 +732,7 @@ class TestCreateWedgeInTimberEnd:
     
     def setup_method(self):
         """Create a standard vertical timber for testing."""
-        self.timber = timber_from_directions(
+        self.timber = create_timber(
             length=scalar(100),
             size=create_v2(scalar(10), scalar(15)),
             bottom_position=create_v3(0, 0, 0),
@@ -832,7 +832,7 @@ class TestTimberRelationshipHelpers:
         """Test are_timbers_parallel helper function."""
         from kumiki.timber_shavings import are_timbers_parallel
         # Create two timbers with parallel length directions
-        timber1 = timber_from_directions(
+        timber1 = create_timber(
             length=scalar(2),
             size=create_v2(scalar("0.2"), scalar("0.3")),
             bottom_position=create_v3(0, 0, 0),
@@ -840,7 +840,7 @@ class TestTimberRelationshipHelpers:
             width_direction=create_v3(1, 0, 0)      # X-right
         )
         
-        timber2 = timber_from_directions(
+        timber2 = create_timber(
             length=scalar(3),
             size=create_v2(scalar("0.15"), scalar("0.25")),
             bottom_position=create_v3(2, 0, 0),
@@ -852,7 +852,7 @@ class TestTimberRelationshipHelpers:
         assert are_timbers_parallel(timber1, timber2)
         
         # Create a timber with opposite direction (still parallel)
-        timber3 = timber_from_directions(
+        timber3 = create_timber(
             length=scalar("1.5"),
             size=create_v2(scalar("0.1"), scalar("0.2")),
             bottom_position=create_v3(-1, 0, 0),
@@ -864,7 +864,7 @@ class TestTimberRelationshipHelpers:
         assert are_timbers_parallel(timber1, timber3)
         
         # Create a timber with perpendicular direction
-        timber4 = timber_from_directions(
+        timber4 = create_timber(
             length=scalar("2.5"),
             size=create_v2(scalar("0.3"), scalar("0.3")),
             bottom_position=create_v3(1, 1, 0),
@@ -879,7 +879,7 @@ class TestTimberRelationshipHelpers:
         """Test are_timbers_orthogonal helper function."""
         from kumiki.timber_shavings import are_timbers_orthogonal
         # Create two timbers with perpendicular length directions
-        timber1 = timber_from_directions(
+        timber1 = create_timber(
             length=scalar(2),
             size=create_v2(scalar("0.2"), scalar("0.3")),
             bottom_position=create_v3(0, 0, 0),
@@ -887,7 +887,7 @@ class TestTimberRelationshipHelpers:
             width_direction=create_v3(1, 0, 0)      # X-right
         )
         
-        timber2 = timber_from_directions(
+        timber2 = create_timber(
             length=scalar(3),
             size=create_v2(scalar("0.15"), scalar("0.25")),
             bottom_position=create_v3(2, 0, 0),
@@ -899,7 +899,7 @@ class TestTimberRelationshipHelpers:
         assert are_timbers_orthogonal(timber1, timber2)
         
         # Create a timber with parallel direction
-        timber3 = timber_from_directions(
+        timber3 = create_timber(
             length=scalar("1.5"),
             size=create_v2(scalar("0.1"), scalar("0.2")),
             bottom_position=create_v3(-1, 0, 0),
@@ -911,7 +911,7 @@ class TestTimberRelationshipHelpers:
         assert not are_timbers_orthogonal(timber1, timber3)
         
         # Test with Y-direction
-        timber4 = timber_from_directions(
+        timber4 = create_timber(
             length=scalar("2.5"),
             size=create_v2(scalar("0.3"), scalar("0.3")),
             bottom_position=create_v3(1, 1, 0),
@@ -926,7 +926,7 @@ class TestTimberRelationshipHelpers:
         """Test are_timbers_face_aligned helper function."""
         from kumiki.timber_shavings import are_timbers_face_aligned
         # Create a reference timber with standard orientation
-        timber1 = timber_from_directions(
+        timber1 = create_timber(
             length=scalar(2),
             size=create_v2(scalar("0.2"), scalar("0.3")),
             bottom_position=create_v3(0, 0, 0),
@@ -936,7 +936,7 @@ class TestTimberRelationshipHelpers:
         # timber1 directions: length=[0,0,1], face=[1,0,0], height=[0,1,0]
         
         # Test 1: Timber with same orientation - should be face-aligned
-        timber2 = timber_from_directions(
+        timber2 = create_timber(
             length=scalar(3),
             size=create_v2(scalar("0.15"), scalar("0.25")),
             bottom_position=create_v3(2, 0, 0),
@@ -947,7 +947,7 @@ class TestTimberRelationshipHelpers:
         
         # Test 2: Timber rotated 90° around Z - should be face-aligned  
         # (length stays Z, but face becomes Y, height becomes -X)
-        timber3 = timber_from_directions(
+        timber3 = create_timber(
             length=scalar("1.5"),
             size=create_v2(scalar("0.1"), scalar("0.2")),
             bottom_position=create_v3(-1, 0, 0),
@@ -958,7 +958,7 @@ class TestTimberRelationshipHelpers:
         
         # Test 3: Timber rotated 90° around X - should be face-aligned
         # (length becomes -Y, face stays X, height becomes Z) 
-        timber4 = timber_from_directions(
+        timber4 = create_timber(
             length=scalar("2.5"),
             size=create_v2(scalar("0.3"), scalar("0.3")),
             bottom_position=create_v3(1, 1, 0),
@@ -969,7 +969,7 @@ class TestTimberRelationshipHelpers:
         
         # Test 4: Timber with perpendicular orientation but face-aligned
         # (length becomes X, face becomes Z, height becomes Y)
-        timber5 = timber_from_directions(
+        timber5 = create_timber(
             length=scalar("1.8"),
             size=create_v2(scalar("0.2"), scalar("0.2")),
             bottom_position=create_v3(0, 2, 0),
@@ -988,7 +988,7 @@ class TestTimberRelationshipHelpers:
         sin45 = math.sin(math.pi/4)
         
         # This creates a timber whose directions don't align with any cardinal axes
-        timber6 = timber_from_directions(
+        timber6 = create_timber(
             length=scalar(1),
             size=create_v2(scalar("0.1"), scalar("0.1")),
             bottom_position=create_v3(0, 0, 2),
@@ -1001,7 +1001,7 @@ class TestTimberRelationshipHelpers:
         # (because height direction is still Z, parallel to timber1's length direction)
         cos45_xy = math.cos(math.pi/4)
         sin45_xy = math.sin(math.pi/4)
-        timber7 = timber_from_directions(
+        timber7 = create_timber(
             length=scalar(1),
             size=create_v2(scalar("0.1"), scalar("0.1")),
             bottom_position=create_v3(0, 0, 2),
@@ -1026,7 +1026,7 @@ class TestTimberRelationshipHelpers:
         from kumiki.timber_shavings import are_timbers_parallel
         
         # Create timbers with exact rational directions
-        timber1 = timber_from_directions(
+        timber1 = create_timber(
             length=2,
             size=create_v2(scalar(1, 5), scalar(3, 10)),
             bottom_position=create_v3(0, 0, 0),
@@ -1034,7 +1034,7 @@ class TestTimberRelationshipHelpers:
             width_direction=create_v3(1, 0, 0)
         )
         
-        timber2 = timber_from_directions(
+        timber2 = create_timber(
             length=3,
             size=create_v2(scalar(1, 10), scalar(1, 4)),
             bottom_position=create_v3(2, 0, 0),
@@ -1046,7 +1046,7 @@ class TestTimberRelationshipHelpers:
         assert are_timbers_parallel(timber1, timber2)
         
         # Test anti-parallel (should still be parallel)
-        timber3 = timber_from_directions(
+        timber3 = create_timber(
             length=scalar(3, 2),
             size=create_v2(scalar(1, 10), scalar(1, 5)),
             bottom_position=create_v3(-1, 0, 0),
@@ -1057,7 +1057,7 @@ class TestTimberRelationshipHelpers:
         assert are_timbers_parallel(timber1, timber3)
         
         # Test perpendicular (should not be parallel)
-        timber4 = timber_from_directions(
+        timber4 = create_timber(
             length=2,
             size=create_v2(scalar(3, 10), scalar(3, 10)),
             bottom_position=create_v3(1, 1, 0),
@@ -1077,7 +1077,7 @@ class TestTimberRelationshipHelpers:
         
         # Slightly off parallel (within tolerance)
         small_angle = 1e-11
-        timber2 = timber_from_directions(
+        timber2 = create_timber(
             length=scalar(3),
             size=create_v2(scalar("0.15"), scalar("0.25")),
             bottom_position=create_v3(scalar(2), scalar(0), scalar(0)),
@@ -1093,7 +1093,7 @@ class TestTimberRelationshipHelpers:
         from kumiki.timber_shavings import are_timbers_orthogonal
         
         # Create timbers with exact rational perpendicular directions
-        timber1 = timber_from_directions(
+        timber1 = create_timber(
             length=2,
             size=create_v2(scalar(1, 5), scalar(3, 10)),
             bottom_position=create_v3(0, 0, 0),
@@ -1101,7 +1101,7 @@ class TestTimberRelationshipHelpers:
             width_direction=create_v3(1, 0, 0)
         )
         
-        timber2 = timber_from_directions(
+        timber2 = create_timber(
             length=3,
             size=create_v2(scalar(15, 100), scalar(1, 4)),
             bottom_position=create_v3(2, 0, 0),
@@ -1113,7 +1113,7 @@ class TestTimberRelationshipHelpers:
         assert are_timbers_orthogonal(timber1, timber2)
         
         # Test non-orthogonal
-        timber3 = timber_from_directions(
+        timber3 = create_timber(
             length=scalar(3, 2),
             size=create_v2(scalar(1, 10), scalar(1, 5)),
             bottom_position=create_v3(-1, 0, 0),
@@ -1133,7 +1133,7 @@ class TestTimberRelationshipHelpers:
         
         # Nearly perpendicular (within numeric fallback test tolerance)
         small_offset = scalar(1e-20)
-        timber2 = timber_from_directions(
+        timber2 = create_timber(
             length=scalar(3),
             size=create_v2(scalar("0.15"), scalar("0.25")),
             bottom_position=create_v3(scalar(2), scalar(0), scalar(0)),
@@ -1148,7 +1148,7 @@ class TestTimberRelationshipHelpers:
         """Test are_timbers_face_aligned with exact equality (no tolerance)."""
         from kumiki.timber_shavings import are_timbers_face_aligned
         # Create two face-aligned timbers using exact rational values
-        timber1 = timber_from_directions(
+        timber1 = create_timber(
             length=2,  # Integer
             size=create_v2(scalar(1, 5), scalar(3, 10)),  # Exact rationals
             bottom_position=create_v3(0, 0, 0),  # Integers
@@ -1156,7 +1156,7 @@ class TestTimberRelationshipHelpers:
             width_direction=create_v3(1, 0, 0)      # East - integers
         )
         
-        timber2 = timber_from_directions(
+        timber2 = create_timber(
             length=3,  # Integer
             size=create_v2(scalar(3, 20), scalar(1, 4)),  # Exact rationals
             bottom_position=create_v3(2, 0, 0),  # Integers
@@ -1169,7 +1169,7 @@ class TestTimberRelationshipHelpers:
         
         # Create a non-face-aligned timber (3D rotation with no aligned axes)
         # Using a timber rotated in 3D such that none of its axes align with timber1's axes
-        timber3 = timber_from_directions(
+        timber3 = create_timber(
             length=2,  # Integer
             size=create_v2(scalar(1, 5), scalar(1, 5)),  # Exact rationals
             bottom_position=create_v3(3, 3, 0),  # Integers
@@ -1191,7 +1191,7 @@ class TestTimberRelationshipHelpers:
         from kumiki.timber_shavings import do_xy_cross_section_on_parallel_timbers_overlap
         
         # Test 1: Two aligned timbers that overlap
-        timber1 = timber_from_directions(
+        timber1 = create_timber(
             length=scalar(10),
             size=create_v2(scalar(4), scalar(4)),
             bottom_position=create_v3(0, 0, 0),
@@ -1200,7 +1200,7 @@ class TestTimberRelationshipHelpers:
             ticket='timber1'
         )
         
-        timber2 = timber_from_directions(
+        timber2 = create_timber(
             length=scalar(10),
             size=create_v2(scalar(4), scalar(4)),
             bottom_position=create_v3(5, 0, 0),
@@ -1213,7 +1213,7 @@ class TestTimberRelationshipHelpers:
             "Aligned timbers at same cross-section should overlap"
         
         # Test 2: Two aligned timbers that don't overlap (separated in Y)
-        timber3 = timber_from_directions(
+        timber3 = create_timber(
             length=scalar(10),
             size=create_v2(scalar(4), scalar(4)),
             bottom_position=create_v3(5, 10, 0),
@@ -1226,7 +1226,7 @@ class TestTimberRelationshipHelpers:
             "Timbers separated in Y should not overlap"
         
         # Test 3: Two rotated timbers that overlap
-        timber4 = timber_from_directions(
+        timber4 = create_timber(
             length=scalar(10),
             size=create_v2(scalar(4), scalar(4)),
             bottom_position=create_v3(0, 0, 0),
@@ -1235,7 +1235,7 @@ class TestTimberRelationshipHelpers:
             ticket='timber4'
         )
         
-        timber5 = timber_from_directions(
+        timber5 = create_timber(
             length=scalar(10),
             size=create_v2(scalar(4), scalar(4)),
             bottom_position=create_v3(0, 0, 0),
@@ -1248,7 +1248,7 @@ class TestTimberRelationshipHelpers:
             "Rotated timbers at same position should overlap"
         
         # Test 4: Timbers that just touch at edge (should overlap)
-        timber6 = timber_from_directions(
+        timber6 = create_timber(
             length=scalar(10),
             size=create_v2(scalar(4), scalar(4)),
             bottom_position=create_v3(0, 0, 0),
@@ -1259,7 +1259,7 @@ class TestTimberRelationshipHelpers:
         
         # timber6 spans Y: -2 to 2
         # timber7 at Y=4 spans Y: 2 to 6, so they just touch
-        timber7 = timber_from_directions(
+        timber7 = create_timber(
             length=scalar(10),
             size=create_v2(scalar(4), scalar(4)),
             bottom_position=create_v3(0, scalar(4), 0),
@@ -1272,7 +1272,7 @@ class TestTimberRelationshipHelpers:
             "Timbers touching at edge should overlap"
         
         # Test 5: Timbers with small gap (should not overlap)
-        timber8 = timber_from_directions(
+        timber8 = create_timber(
             length=scalar(10),
             size=create_v2(scalar(4), scalar(4)),
             bottom_position=create_v3(0, scalar(4) + scalar('0.01'), 0),
@@ -1285,7 +1285,7 @@ class TestTimberRelationshipHelpers:
             "Timbers with small gap should not overlap"
         
         # Test 6: Anti-parallel timbers (same direction but opposite ends)
-        timber9 = timber_from_directions(
+        timber9 = create_timber(
             length=scalar(10),
             size=create_v2(scalar(4), scalar(4)),
             bottom_position=create_v3(0, 0, 0),
@@ -1294,7 +1294,7 @@ class TestTimberRelationshipHelpers:
             ticket='timber9'
         )
         
-        timber10 = timber_from_directions(
+        timber10 = create_timber(
             length=scalar(10),
             size=create_v2(scalar(4), scalar(4)),
             bottom_position=create_v3(20, 0, 0),
@@ -1307,7 +1307,7 @@ class TestTimberRelationshipHelpers:
             "Anti-parallel timbers at same cross-section should overlap"
         
         # Test 7: Offset rotated timbers
-        timber11 = timber_from_directions(
+        timber11 = create_timber(
             length=scalar(10),
             size=create_v2(scalar(4), scalar(6)),  # 4 wide, 6 high
             bottom_position=create_v3(0, 0, 0),
@@ -1317,7 +1317,7 @@ class TestTimberRelationshipHelpers:
         )
         
         # Rotated 90 degrees and offset
-        timber12 = timber_from_directions(
+        timber12 = create_timber(
             length=scalar(10),
             size=create_v2(scalar(6), scalar(4)),  # 6 wide, 4 high
             bottom_position=create_v3(scalar(4), 0, 0),  # Offset in X
@@ -1333,7 +1333,7 @@ class TestTimberRelationshipHelpers:
             "Offset rotated timbers with partial overlap should overlap"
         
         # Test 8: Assertion error for non-parallel timbers
-        timber13 = timber_from_directions(
+        timber13 = create_timber(
             length=scalar(10),
             size=create_v2(scalar(4), scalar(4)),
             bottom_position=create_v3(0, 0, 0),
@@ -1342,7 +1342,7 @@ class TestTimberRelationshipHelpers:
             ticket='timber13'
         )
         
-        timber14 = timber_from_directions(
+        timber14 = create_timber(
             length=scalar(10),
             size=create_v2(scalar(4), scalar(4)),
             bottom_position=create_v3(0, 0, 0),

--- a/tests/testing_shavings.py
+++ b/tests/testing_shavings.py
@@ -54,7 +54,7 @@ def create_standard_vertical_timber(
     if position is None:
         position = (scalar(0), scalar(0), scalar(0))
     
-    return timber_from_directions(
+    return create_timber(
         length=scalar(height),
         size=Matrix([scalar(size[0]), scalar(size[1])]),
         bottom_position=Matrix([scalar(position[0]), scalar(position[1]), scalar(position[2])]),
@@ -102,7 +102,7 @@ def create_standard_horizontal_timber(
     
     length_dir, width_dir = direction_map[direction]
     
-    return timber_from_directions(
+    return create_timber(
         length=scalar(length),
         size=Matrix([scalar(size[0]), scalar(size[1])]),
         bottom_position=Matrix([scalar(position[0]), scalar(position[1]), scalar(position[2])]),


### PR DESCRIPTION
## Summary
- Resolves the `# TODO rename to create_timber (or maybe hew lolololol) + add defaults` on `kumiki.timber.timber_from_directions` by renaming it to `create_timber` (the "add defaults" part of the TODO is left for a follow-up).
- Removes `kumiki.construction.create_timber`, which was a thin wrapper around `timber_from_directions` with the `bottom_position` and `length`/`size` arguments swapped — now redundant since it shares the same name and module namespace (`construction.py` does `from kumiki.timber import *`).
- Updates every call site across `kumiki/`, `patterns/`, `tests/`, `kigumi/`, `garbage/`, and docs to the single merged `create_timber(length, size, bottom_position, length_direction, width_direction, ticket=None)` signature — including reordering the handful of call sites that used the old wrapper's positional argument order.
- Folds the wrapper's "AGENT NOTE: AVOID this function if possible..." docstring guidance into the surviving `create_timber` so it isn't lost.

## Test plan
- [x] `python3 -m pytest tests/ -q` — 742 passed, 4 skipped
- [x] `uv run ty check` — all checks passed
- [x] `python3 -m py_compile` on all `patterns/`, `garbage/`, and `kigumi` fixture files
- [x] Instantiated all 73 patterns via `Pattern.lambda_(center)` and all `kigumi/test-fixtures/*.py` frame builders — all succeed
- [x] Note: `kigumi/test-frame.py` fails with `unexpected keyword argument 'name'` — pre-existing bug on `origin/main` unrelated to this rename (should be `ticket=`, not `name=`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)