### PR TITLE
Groundwork for measuring by picking

### DIFF
--- a/TODO.txt
+++ b/TODO.txt
@@ -301,7 +301,9 @@ DONE-Fix the feature stable reference issue:
   - _serialize_csg_node numbers only the aligned top-level subtract children, so the tree payload's deeper segments are bare too.
 
 
--TODO should we enforce canonical ordering on anchor_a / anchor_b, we can create a new class CanonicalFeaturePathPair or something
+DONE-TODO should we enforce canonical ordering on anchor_a / anchor_b, we can create a new class CanonicalFeaturePathPair or something
+DONE-consider dropping kind from measurement identity when checking for override on python 
+
 -add support for 3d measurements
 
 -increase edge selsection threhsold...
@@ -313,6 +315,23 @@ DONE-Fix the feature stable reference issue:
 -right now edges are intersecting with rough surface (which may line up with perfect)... but we should probably perfer perfect... figure out the rule for this
   for rough vs ptw, the rule is acutally when cilkcing in the editor, it's fine, if its showing rough it's rough if it's showing ptw it's ptw based on render settings. for drawings, we should actually raycast onto both ptw and rough, if they hapen to coincide prefer ptw, and then if you ever have ae measurement against rough, put an asterix on it or osmetihng in tree view to indicate it's being measured froma rough surface. what dyou think about that?
 
+
+-erdo website w/ actually how the program works details
+  -do the sliding navigation galrlery thing at the top
+  -rephrase as "programmatic cad"
+  -first clickable bullet: program your frames
+    -highilght AI workflow
+    -code <-> preview sample
+  -second clickable bullet: live preview in kigumi
+    -highlight all features
+  -third cilkcable bullet: real parametric joinery
+    -joint exapmles, with different configuartions
+  -drawing generation (COMING SOON)
+    -automatic generation -> customize in code -> manual override in kigumi
+  -assembly generation (BETA)
+    -assembly video
+
+-update decorative end cut to use front face axis as the angle direction
 
 
 

--- a/kigumi/__tests__/measure-mode.test.js
+++ b/kigumi/__tests__/measure-mode.test.js
@@ -1,0 +1,177 @@
+const { MeasureMode, sameReference, STATES } = require('../webview/measure-mode.js');
+
+function face(feature, path = ['cut'], timber = 'post#0') {
+    return { pick: { reference: { timber, csgPath: path, feature, type: 'FACE' } } };
+}
+
+function edge(a, b, timber = 'post#0') {
+    return {
+        pick: {
+            reference: {
+                kind: 'edge',
+                timber,
+                a: { csgPath: ['cut'], feature: a },
+                b: { csgPath: ['body'], feature: b },
+            },
+        },
+    };
+}
+
+describe('measure mode', () => {
+    it('starts off', () => {
+        expect(new MeasureMode().state).toBe(STATES.OFF);
+        expect(new MeasureMode().isActive).toBe(false);
+    });
+
+    it('the first pick enters the mode and holds one end', () => {
+        const mode = new MeasureMode();
+
+        const result = mode.pick(face('a').pick, 'front');
+
+        expect(result.action).toBe('from');
+        expect(mode.state).toBe(STATES.FROM);
+        expect(mode.measurement).toBeNull();
+    });
+
+    it('the second pick makes the measurement', () => {
+        const mode = new MeasureMode();
+        mode.pick(face('a').pick, 'front');
+
+        const result = mode.pick(face('b').pick, 'front');
+
+        expect(result.action).toBe('to');
+        expect(mode.state).toBe(STATES.BETWEEN);
+        expect(result.measurement.a.feature).toBe('a');
+        expect(result.measurement.b.feature).toBe('b');
+    });
+
+    it('the measurement belongs to the viewport the first pick was in', () => {
+        const mode = new MeasureMode();
+        mode.pick(face('a').pick, 'front');
+        mode.pick(face('b').pick, 'top');
+
+        expect(mode.measurement.viewportId).toBe('front');
+    });
+
+    it('a third pick replaces the second rather than making another', () => {
+        // The misclick case: one measurement in flight, never two.
+        const mode = new MeasureMode();
+        mode.pick(face('a').pick, 'front');
+        mode.pick(face('b').pick, 'front');
+
+        const result = mode.pick(face('c').pick, 'front');
+
+        expect(result.action).toBe('replaced');
+        expect(mode.measurement.b.feature).toBe('c');
+        expect(mode.state).toBe(STATES.BETWEEN);
+    });
+
+    it('escape from two ends releases the second and keeps the first', () => {
+        const mode = new MeasureMode();
+        mode.pick(face('a').pick, 'front');
+        mode.pick(face('b').pick, 'front');
+
+        const result = mode.escape();
+
+        expect(result.action).toBe('released-to');
+        expect(mode.state).toBe(STATES.FROM);
+        expect(mode.measurement).toBeNull();
+    });
+
+    it('escape from one end leaves the mode', () => {
+        const mode = new MeasureMode();
+        mode.pick(face('a').pick, 'front');
+
+        const result = mode.escape();
+
+        expect(result.action).toBe('left');
+        expect(mode.state).toBe(STATES.OFF);
+        expect(mode.isActive).toBe(false);
+    });
+
+    it('leaving takes two escapes from two ends', () => {
+        const mode = new MeasureMode();
+        mode.pick(face('a').pick, 'front');
+        mode.pick(face('b').pick, 'front');
+
+        mode.escape();
+        mode.escape();
+
+        expect(mode.state).toBe(STATES.OFF);
+    });
+
+    it('escape does nothing when nothing is held', () => {
+        expect(new MeasureMode().escape().action).toBe('none');
+    });
+
+    it('leaving releases both ends at once', () => {
+        const mode = new MeasureMode();
+        mode.pick(face('a').pick, 'front');
+        mode.pick(face('b').pick, 'front');
+
+        expect(mode.leave().action).toBe('left');
+        expect(mode.state).toBe(STATES.OFF);
+    });
+
+    it('a pick that names no feature is refused', () => {
+        // Still drilling down through compounds, so there is nothing to measure.
+        const mode = new MeasureMode();
+
+        const result = mode.pick({ path: ['cut'] }, 'front');
+
+        expect(result.action).toBe('refused');
+        expect(result.reason).toBe('no-feature');
+        expect(mode.state).toBe(STATES.OFF);
+    });
+
+    it('measuring a feature to itself is refused', () => {
+        const mode = new MeasureMode();
+        mode.pick(face('a').pick, 'front');
+
+        const result = mode.pick(face('a').pick, 'front');
+
+        expect(result.action).toBe('refused');
+        expect(result.reason).toBe('same-feature');
+        expect(mode.state).toBe(STATES.FROM);
+    });
+});
+
+describe('comparing references', () => {
+    it('the same face is the same reference', () => {
+        expect(sameReference(face('a').pick.reference, face('a').pick.reference)).toBe(true);
+    });
+
+    it('the same feature name on a different node is not', () => {
+        expect(sameReference(
+            face('a', ['cut']).pick.reference,
+            face('a', ['other']).pick.reference,
+        )).toBe(false);
+    });
+
+    it('the same feature name on a different timber is not', () => {
+        expect(sameReference(
+            face('a', ['cut'], 'post#0').pick.reference,
+            face('a', ['cut'], 'post#1').pick.reference,
+        )).toBe(false);
+    });
+
+    it('an edge is the same edge written either way round', () => {
+        // The rule DerivedFeaturePath applies when it sorts its parents.
+        const one = edge('mortise_right', 'rough.left').pick.reference;
+        const other = {
+            kind: 'edge',
+            timber: 'post#0',
+            a: { csgPath: ['body'], feature: 'rough.left' },
+            b: { csgPath: ['cut'], feature: 'mortise_right' },
+        };
+
+        expect(sameReference(one, other)).toBe(true);
+    });
+
+    it('an edge and a face are never the same', () => {
+        expect(sameReference(
+            edge('mortise_right', 'rough.left').pick.reference,
+            face('mortise_right').pick.reference,
+        )).toBe(false);
+    });
+});

--- a/kigumi/runner.py
+++ b/kigumi/runner.py
@@ -1652,6 +1652,14 @@ def _feature_path_identity(anchor: Any) -> Tuple[str, Tuple[str, ...], str, str]
     return path.identity()
 
 
+def _measure_pair_identity(measure: Dict[str, Any]) -> Tuple[Any, Any]:
+    """Just the two features of a measurement, without what is measured between."""
+    return tuple(sorted((
+        _feature_path_identity(measure.get("a")),
+        _feature_path_identity(measure.get("b")),
+    )))
+
+
 def _measure_identity(measure: Dict[str, Any]) -> Tuple[Any, Any, str]:
     """What makes a measurement itself, within the viewport it is drawn in.
 
@@ -1783,11 +1791,26 @@ def merge_measurements(
             _duplicate_warning_given = True
         from_file[identity] = measure
 
+    from kumiki.drawing import MeasurementSource, does_override_identities
+
     merged: List[Dict[str, Any]] = []
     used = set()
     for measure in code_measures:
         identity = _measure_identity(measure)
-        override = from_file.get(identity)
+        # Through does_override rather than a bare lookup, so the rule about
+        # what replaces what lives in one place. For these two tiers it is a
+        # full match, which is what the dict already did -- but it is the rule
+        # that says so, not this loop.
+        override = None
+        for candidate_identity, candidate in from_file.items():
+            if does_override_identities(
+                candidate_identity, _measure_pair_identity(candidate),
+                MeasurementSource.FILE_OVERRIDE,
+                identity, _measure_pair_identity(measure),
+                MeasurementSource.PYTHON_CODED,
+            ):
+                override, identity = candidate, candidate_identity
+                break
         if override is None:
             merged.append({**measure, "origin": ORIGIN_CODE})
             continue

--- a/kigumi/runner.py
+++ b/kigumi/runner.py
@@ -1723,10 +1723,16 @@ def deserialize_feature_path(source: Any) -> Optional[Any]:
 
 
 def _serialize_code_measure(measure: Any) -> Dict[str, Any]:
+    placement = getattr(measure, "placement", None)
     return {
         "a": serialize_feature_path(measure.anchor_a),
         "b": serialize_feature_path(measure.anchor_b),
         "measureId": str(measure.measure_id) if measure.measure_id else None,
+        # Neither is part of identity: asking for a different kind, or moving
+        # the line, is not measuring something else. They travel so that
+        # overriding one in the file starts from what the code asked for.
+        "kind": measure.kind.name if getattr(measure, "kind", None) else None,
+        "placement": {"offset": placement.offset} if placement is not None else None,
         "origin": ORIGIN_CODE,
     }
 
@@ -3854,6 +3860,44 @@ def _navigate_csg_to_leaf(
         node = target
 
 
+def _pick_reference(
+    local_csg: Any,
+    member_key: str,
+    node_path: List[str],
+    feature_label: Optional[str],
+    feature_type: Optional[str],
+    edge: Any = None,
+) -> Optional[Dict[str, Any]]:
+    """The reference a measurement would hold for what was just picked.
+
+    None while a click is still drilling down through compounds and has not
+    reached a feature, and None for a derived edge whose parents cannot both be
+    placed in the tree -- neither is something to measure to yet.
+    """
+    from kumiki.identity import (DerivedFeaturePath, FeatureRef, ResolvedTimberPath,
+                                 SingleFeaturePath)
+
+    if feature_label is None:
+        return None
+    timber = ResolvedTimberPath.parse(member_key)
+
+    if edge is not None:
+        positions = _node_positions(local_csg)
+        parents = []
+        for hit in (getattr(edge, "a", None), getattr(edge, "b", None)):
+            if hit is None or id(hit.owner) not in positions:
+                return None
+            parents.append(FeatureRef(tuple(positions[id(hit.owner)][2]), hit.feature.name))
+        return serialize_feature_path(
+            DerivedFeaturePath(timber=timber, a=parents[0], b=parents[1]))
+
+    return serialize_feature_path(SingleFeaturePath(
+        timber=timber,
+        ref=FeatureRef(tuple(node_path), feature_label),
+        feature_type=feature_type,
+    ))
+
+
 def _extract_highlight_mesh(
     mesh_vertices: List[float],
     mesh_indices: List[int],
@@ -4052,6 +4096,13 @@ def _handle_find_csg_at_point(state: RunnerState, payload: Dict[str, Any], slot_
         # once, so it cannot infer which one a result belongs to.
         "memberKey": member_key,
         "path": new_path,
+        # What a measurement would hold if this pick became one. Built here
+        # because only the runner can see the CSG a path has to be read against
+        # -- an edge in particular is not a feature anyone declared, so it has
+        # to name the two faces that form it.
+        "reference": _pick_reference(
+            local_csg, member_key, new_path, feature_label, feature_type, edge,
+        ),
         # What was selected, and the feature within it if navigation resolved
         # one. feature_label is None while a click is still drilling down
         # through compounds, and the display has to say so rather than name a

--- a/kigumi/runner.py
+++ b/kigumi/runner.py
@@ -1655,17 +1655,30 @@ def _feature_path_identity(anchor: Any) -> Tuple[str, Tuple[str, ...], str, str]
 def _measure_identity(measure: Dict[str, Any]) -> Tuple[Any, Any, str]:
     """What makes a measurement itself, within the viewport it is drawn in.
 
-    The anchors unordered, since measuring A to B is measuring B to A, plus an
-    id for when the same pair is measured twice in the same viewport. Scoped to
+    The anchors unordered, since measuring A to B is measuring B to A. Then the
+    kind, because two kinds between one pair are two dimensions and both should
+    show. Then an id, for the same pair measured twice the same way. Scoped to
     the viewport because that is where a measurement lives: the same anchors in
     the plan view are a different dimension with a different number, not this
     one seen from elsewhere.
+
+    The same tuple Measure.identity builds, because the two are compared
+    against each other -- a file measurement overrides a code one by matching
+    it. A kind is normalized through MeasurementKind first, so one written
+    under an older name matches the same kind written under the new one.
     """
+    from kumiki.drawing import Measure, MeasurementKind
+
     first, second = sorted((
         _feature_path_identity(measure.get("a")),
         _feature_path_identity(measure.get("b")),
     ))
-    return (first, second, str(measure.get("measureId") or ""))
+    kind = measure.get("kind")
+    return (
+        first, second,
+        Measure.kind_identity(MeasurementKind.from_wire(kind) if kind else None),
+        str(measure.get("measureId") or ""),
+    )
 
 
 def serialize_feature_path(path: Any) -> Dict[str, Any]:

--- a/kigumi/webview/measure-mode.js
+++ b/kigumi/webview/measure-mode.js
@@ -1,0 +1,185 @@
+(function (globalScope) {
+    'use strict';
+    // Making a measurement by picking, as a state machine and nothing else.
+    //
+    // No DOM, no scene, no runner: it takes picks and Escapes and says what the
+    // measurement is now. That is what makes the awkward part -- which pick
+    // replaces which -- something you can read in one place and test without a
+    // viewer.
+    //
+    //
+    // THE STATES
+    //
+    //   OFF        not in a drawing, or nothing picked yet.
+    //   FROM       one feature held. This is what "measurement mode" means:
+    //              picking a feature in a drawing enters it.
+    //   BETWEEN    two features held, and a measurement exists between them.
+    //
+    //
+    // THE MOVES
+    //
+    //   state     input     goes to    and
+    //   -------   -------   --------   ---------------------------------------
+    //   OFF       pick A    FROM       A is held
+    //   FROM      pick B    BETWEEN    the measurement A-B is made
+    //   FROM      escape    OFF        A released, mode left
+    //   BETWEEN   pick C    BETWEEN    B replaced by C; the SAME measurement
+    //                                  now reads A-C. For a misclick, so it
+    //                                  does not leave a wrong one behind.
+    //   BETWEEN   escape    FROM       B released, measurement removed, A kept
+    //   any       leave     OFF        everything released
+    //
+    // Escape pops one step, which is why leaving takes two from BETWEEN. There
+    // is only ever one measurement in flight: a second pick makes it and every
+    // pick after edits it, so measuring the same pair twice cannot happen by
+    // accident and no id has to be minted to tell two of them apart.
+    //
+    // Selecting a feature in a drawing is always the start of a measurement --
+    // there is no plain "look at this one" selection while in a drawing. Both
+    // feature and measurement selections are cleared when the mode changes, so
+    // nothing is left highlighted that the current mode cannot act on.
+
+    const OFF = 'off';
+    const FROM = 'from';
+    const BETWEEN = 'between';
+
+    /**
+     * Whether a pick can be measured to, and why not when it cannot.
+     *
+     * The reference is what a measurement would hold; without one the pick is
+     * still drilling through compounds and names no feature yet.
+     */
+    function pickIsMeasurable(pick) {
+        if (!pick || !pick.reference) {
+            return { ok: false, reason: 'no-feature' };
+        }
+        return { ok: true };
+    }
+
+    class MeasureMode {
+        constructor() {
+            this.reset();
+        }
+
+        reset() {
+            this.state = OFF;
+            this.from = null;
+            this.to = null;
+            /** The viewport the first pick landed in; the measurement lives there. */
+            this.viewportId = null;
+        }
+
+        get isActive() {
+            return this.state !== OFF;
+        }
+
+        /** The measurement as it stands, or null while only one end is held. */
+        get measurement() {
+            if (this.state !== BETWEEN) {
+                return null;
+            }
+            return { a: this.from, b: this.to, viewportId: this.viewportId };
+        }
+
+        /**
+         * A feature was picked.
+         *
+         * Returns what happened, so the caller can report a refusal rather than
+         * silently doing nothing: {action, reason?, measurement?}.
+         */
+        pick(pick, viewportId) {
+            const measurable = pickIsMeasurable(pick);
+            if (!measurable.ok) {
+                return { action: 'refused', reason: measurable.reason };
+            }
+            const reference = pick.reference;
+
+            if (this.state === OFF) {
+                this.from = reference;
+                this.viewportId = viewportId === undefined ? null : viewportId;
+                this.state = FROM;
+                return { action: 'from' };
+            }
+
+            // The second end, and every one after it, is the same end being
+            // chosen again. A measurement to a feature already at the other end
+            // measures nothing, so it is refused rather than made.
+            if (sameReference(reference, this.from)) {
+                return { action: 'refused', reason: 'same-feature' };
+            }
+
+            const replacing = this.state === BETWEEN;
+            this.to = reference;
+            this.state = BETWEEN;
+            return {
+                action: replacing ? 'replaced' : 'to',
+                measurement: this.measurement,
+            };
+        }
+
+        /** Escape: release the most recent end. */
+        escape() {
+            if (this.state === BETWEEN) {
+                this.to = null;
+                this.state = FROM;
+                return { action: 'released-to' };
+            }
+            if (this.state === FROM) {
+                this.reset();
+                return { action: 'left' };
+            }
+            return { action: 'none' };
+        }
+
+        /** Leaving the drawing, or switching modes: hold nothing. */
+        leave() {
+            const wasActive = this.isActive;
+            this.reset();
+            return { action: wasActive ? 'left' : 'none' };
+        }
+    }
+
+    /** Whether two references name the same thing, by their wire form. */
+    function sameReference(one, other) {
+        if (!one || !other) {
+            return false;
+        }
+        return JSON.stringify(referenceKey(one)) === JSON.stringify(referenceKey(other));
+    }
+
+    /**
+     * A comparable form of a reference.
+     *
+     * An edge's two parents are sorted, because the same edge written either
+     * way round is the same edge -- the same rule DerivedFeaturePath applies
+     * when it sorts its parents on the python side.
+     */
+    function referenceKey(reference) {
+        if (reference.kind === 'edge') {
+            const parents = [reference.a, reference.b]
+                .map((part) => [((part || {}).csgPath || []).join('/'), (part || {}).feature || ''])
+                .sort();
+            return [reference.timber, 'edge', parents];
+        }
+        return [
+            reference.timber,
+            'single',
+            (reference.csgPath || []).join('/'),
+            reference.feature || '',
+            reference.type || '',
+        ];
+    }
+
+    const KigumiMeasureMode = {
+        MeasureMode,
+        sameReference,
+        referenceKey,
+        pickIsMeasurable,
+        STATES: { OFF, FROM, BETWEEN },
+    };
+
+    if (typeof module !== 'undefined' && module.exports) {
+        module.exports = KigumiMeasureMode;
+    }
+    globalScope.KigumiMeasureMode = KigumiMeasureMode;
+})(typeof window !== 'undefined' ? window : globalThis);

--- a/kumiki/__init__.py
+++ b/kumiki/__init__.py
@@ -36,7 +36,7 @@ from .identity import (
     TimberPath,
     ViewportId,
 )
-from .drawing import Drawing, Measure, MeasureKind
+from .drawing import Drawing, Measure, MeasureKind, MeasurementPlacement
 from .timber import *
 from .footprint import *
 from .construction import *

--- a/kumiki/drawing.py
+++ b/kumiki/drawing.py
@@ -362,6 +362,10 @@ class Measure:
         wire = kind.as_wire()
         return (wire["operation"], wire["space"], wire["direction"])
 
+    def pair_identity(self) -> Tuple[Tuple, Tuple]:
+        """Just the two features, without saying what is measured between them."""
+        return (self.anchor_a.identity(), self.anchor_b.identity())
+
     def identity(self) -> Tuple[Tuple, Tuple, Tuple, str]:
         """What makes this measurement itself, within its viewport.
 
@@ -386,6 +390,81 @@ class Measure:
             self.kind_identity(self.kind),
             str(self.measure_id or ""),
         )
+
+
+class MeasurementSource(Enum):
+    """Where a measurement came from, which decides what it may replace.
+
+    Three tiers, each able to replace the ones below it and nothing else. An
+    algorithm proposes, a person writing code decides, and the drawings file --
+    which is to say the viewer -- has the last word.
+    """
+
+    #: An algorithm produced it. Replaceable by anything.
+    PYTHON_GENERATED = "python_generated"
+    #: Somebody wrote it in the frame's code.
+    PYTHON_CODED = "python_coded"
+    #: The drawings file, written by the viewer or by hand.
+    FILE_OVERRIDE = "file_override"
+
+
+_SOURCE_RANK = {
+    MeasurementSource.PYTHON_GENERATED: 0,
+    MeasurementSource.PYTHON_CODED: 1,
+    MeasurementSource.FILE_OVERRIDE: 2,
+}
+
+
+def does_override(
+    candidate: Measure,
+    existing: Measure,
+    candidate_source: MeasurementSource,
+    existing_source: MeasurementSource,
+) -> bool:
+    """Whether *candidate* replaces *existing*, rather than sitting beside it.
+
+    A tier only replaces one below it: two measurements from the same tier are
+    two measurements, however alike, and a lower tier never displaces a higher.
+
+    What counts as the same measurement depends on which tier is asking, and
+    the difference is the kind:
+
+    - A FILE_OVERRIDE matches on everything, kind included. It was written
+      against a particular measurement -- the horizontal one, say -- and the
+      vertical between the same two features is a different dimension it was
+      never about. Changing a kind is therefore not an edit but a different
+      measurement, said as suppressing one and adding another.
+
+    - Anything else matches on the two features alone. A person writing a
+      measurement in code is overruling what an algorithm proposed for that
+      pair, and would have to guess the generated kind to say so otherwise --
+      which is exactly the sort of thing that stops working when the algorithm
+      is next changed.
+    """
+    return does_override_identities(
+        candidate.identity(), candidate.pair_identity(), candidate_source,
+        existing.identity(), existing.pair_identity(), existing_source,
+    )
+
+
+def does_override_identities(
+    candidate_identity: Tuple,
+    candidate_pair: Tuple,
+    candidate_source: MeasurementSource,
+    existing_identity: Tuple,
+    existing_pair: Tuple,
+    existing_source: MeasurementSource,
+) -> bool:
+    """does_override, for a caller holding identities rather than Measures.
+
+    The viewer reads measurements out of a file as plain dictionaries and never
+    builds a Measure from them, so the rule lives here where both can reach it.
+    """
+    if _SOURCE_RANK[candidate_source] <= _SOURCE_RANK[existing_source]:
+        return False
+    if candidate_source is MeasurementSource.FILE_OVERRIDE:
+        return candidate_identity == existing_identity
+    return candidate_pair == existing_pair
 
 
 @dataclass(frozen=True)

--- a/kumiki/drawing.py
+++ b/kumiki/drawing.py
@@ -13,7 +13,7 @@ are two dimensions with two numbers, and either may be meaningless while the
 other is fine.
 """
 
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from enum import Enum
 from typing import Mapping, Optional, Tuple
 
@@ -314,14 +314,78 @@ class Measure:
             object.__setattr__(self, 'kind', MeasurementKind.from_wire(self.kind))
         if isinstance(self.placement, dict):
             object.__setattr__(self, 'placement', MeasurementPlacement(**self.placement))
+        self._canonicalise_anchors()
 
-    def identity(self) -> Tuple[Tuple, Tuple, str]:
+    def _canonicalise_anchors(self) -> None:
+        """Put the two anchors in one order, so a pair cannot be written twice.
+
+        Measuring A to B and measuring B to A are the same measurement, and
+        without this they are two: two entries in a viewport, two dimensions
+        drawn on top of each other, and a file override that matches neither.
+        Sorting at creation means there is only ever one way to write it down.
+
+        Swapping is safe because every kind there is today is symmetric -- each
+        computes an absolute value or a length, so the number does not depend on
+        which anchor came first. The one thing that does is which SIDE the
+        dimension line sits on, since it is offset perpendicular to the run
+        between the anchors, and reversing the run reverses the perpendicular.
+        The offset is signed, so negating it puts the line back where it was.
+
+        WHEN AN ASYMMETRIC KIND ARRIVES -- one where A to B and B to A are
+        genuinely different measurements, rather than the same one drawn from
+        the other end -- this has to stop being unconditional and start asking
+        the kind. It is written here rather than left to be discovered because
+        by then the ordering will look like something nothing depends on.
+        """
+        if self.anchor_a is None or self.anchor_b is None:
+            return
+        first, second = self.anchor_a, self.anchor_b
+        if first.identity() <= second.identity():
+            return
+        object.__setattr__(self, 'anchor_a', second)
+        object.__setattr__(self, 'anchor_b', first)
+        if self.placement is not None and self.placement.offset is not None:
+            object.__setattr__(
+                self, 'placement',
+                replace(self.placement, offset=-self.placement.offset))
+
+    @staticmethod
+    def kind_identity(kind: Optional['MeasurementKind']) -> Tuple:
+        """A kind in a comparable form, or an empty one for "whichever is natural".
+
+        The parts rather than the name, because a name can arrive as an older
+        one -- `angle` and `projected_angle` are the same kind written years
+        apart, and must not read as two different measurements.
+        """
+        if kind is None:
+            return ()
+        wire = kind.as_wire()
+        return (wire["operation"], wire["space"], wire["direction"])
+
+    def identity(self) -> Tuple[Tuple, Tuple, Tuple, str]:
         """What makes this measurement itself, within its viewport.
 
-        The anchors unordered, since measuring A to B is measuring B to A.
+        The anchors come already in one order (see _canonicalise_anchors), so
+        measuring A to B and measuring B to A are one measurement.
+
+        The kind is part of it, because two kinds between one pair are two
+        dimensions and both should show: the horizontal and the vertical
+        between the same two points is an ordinary thing to want. The
+        alternative was making the author mint a measure_id to tell them apart,
+        which is a chore for the common case.
+
+        The cost, which the editing flow has to know about: changing a
+        measurement's kind changes its identity. So an override cannot edit a
+        code measurement's kind in place -- it is a different measurement now.
+        Say it as suppressing the original and adding the new one, which is
+        what those two mechanisms are already for.
         """
-        first, second = sorted((self.anchor_a.identity(), self.anchor_b.identity()))
-        return (first, second, str(self.measure_id or ""))
+        return (
+            self.anchor_a.identity(),
+            self.anchor_b.identity(),
+            self.kind_identity(self.kind),
+            str(self.measure_id or ""),
+        )
 
 
 @dataclass(frozen=True)

--- a/kumiki/drawing.py
+++ b/kumiki/drawing.py
@@ -77,6 +77,24 @@ class MeasureKind(Enum):
 
 
 @dataclass(frozen=True)
+class MeasurementPlacement:
+    """Where a dimension sits, as distinct from what it measures.
+
+    Its own object rather than a bare number because placement grows: which
+    side of the feature the line sits on, where the text goes when it will not
+    fit between the arrows, whether a witness line is drawn. `offset` is the
+    only one of those that exists yet.
+
+    None throughout means "wherever the viewport puts it", which is what every
+    measurement written before placement existed means.
+    """
+
+    #: How far the dimension line sits from the features, in page units.
+    #: None asks the viewport for its own default.
+    offset: Optional[float] = None
+
+
+@dataclass(frozen=True)
 class Measure:
     """A dimension between two features, drawn in one viewport.
 
@@ -95,12 +113,17 @@ class Measure:
     #: features project to there.
     kind: Optional[MeasureKind] = None
     measure_id: Optional[MeasurementId] = None
+    #: Where the dimension sits. Deliberately not part of identity: moving a
+    #: dimension line is not measuring something else.
+    placement: Optional[MeasurementPlacement] = None
 
     def __post_init__(self):
         if isinstance(self.measure_id, str):
             object.__setattr__(self, 'measure_id', MeasurementId(self.measure_id))
         if isinstance(self.kind, str):
             object.__setattr__(self, 'kind', MeasureKind(self.kind))
+        if isinstance(self.placement, dict):
+            object.__setattr__(self, 'placement', MeasurementPlacement(**self.placement))
 
     def identity(self) -> Tuple[Tuple, Tuple, str]:
         """What makes this measurement itself, within its viewport.

--- a/tests/test_kigumi_csg_navigation.py
+++ b/tests/test_kigumi_csg_navigation.py
@@ -1316,3 +1316,73 @@ class TestSameNamedSiblings:
         found = [runner._find_csg_by_labels(root, labels) for root in roots]
 
         assert all(node is None for node in found)
+
+
+class TestPickYieldsAMeasurementReference:
+    """What a pick hands back for a measurement to hold.
+
+    Only the runner can build this: a path means nothing without the CSG it is
+    read against, and a derived edge is not a declared feature at all, so it has
+    to name the two faces that form it.
+    """
+
+    def _pick_at(self, frame, member, predicate):
+        from kumiki.triangles import triangulate_cutcsg
+
+        cut_timber = _cut_timber_by_name(frame, member)
+        local = cut_timber.render_timber_with_cuts_csg_local()
+        for triangle in triangulate_cutcsg(local).mesh.triangles:
+            for vertex in triangle:
+                point = runner._to_v3([float(vertex[i]) for i in range(3)])
+                for hit in local.get_all_features(point):
+                    if predicate(hit.feature):
+                        return local, hit.feature
+        raise AssertionError("no such feature on the finished surface")
+
+    def test_a_face_pick_references_that_face(self, mortise_and_tenon_frame):
+        from kumiki.cutcsg import CSGFeatureType
+
+        local, feature = self._pick_at(
+            mortise_and_tenon_frame, "receiving_timber",
+            lambda f: f.feature_type() == CSGFeatureType.FACE and f.name.startswith("mortise"))
+
+        reference = runner._pick_reference(
+            local, "receiving_timber#0", ["mortise_and_tenon", "mortise_hole"],
+            feature.name, "FACE", None)
+
+        assert reference["timber"] == "receiving_timber#0"
+        assert reference["feature"] == feature.name
+        assert reference.get("kind") != "edge"
+
+    def test_an_edge_pick_references_both_its_parents(self, mortise_and_tenon_frame):
+        from kumiki.cutcsg import CSGFeatureType
+
+        local, edge = self._pick_at(
+            mortise_and_tenon_frame, "receiving_timber",
+            lambda f: f.feature_type() == CSGFeatureType.EDGE)
+
+        reference = runner._pick_reference(
+            local, "receiving_timber#0", [], edge.name, "EDGE", edge)
+
+        assert reference["kind"] == "edge"
+        assert {reference["a"]["feature"], reference["b"]["feature"]} == {
+            edge.a.feature.name, edge.b.feature.name}
+
+    def test_the_reference_resolves_back_to_a_place(self, mortise_and_tenon_frame):
+        # The round trip that matters: what a pick writes down, resolve_anchor
+        # finds again.
+        from kumiki.cutcsg import CSGFeatureType
+
+        local, edge = self._pick_at(
+            mortise_and_tenon_frame, "receiving_timber",
+            lambda f: f.feature_type() == CSGFeatureType.EDGE)
+        reference = runner._pick_reference(
+            local, "receiving_timber#0", [], edge.name, "EDGE", edge)
+
+        resolved = runner.resolve_anchor(mortise_and_tenon_frame, reference)
+
+        assert resolved is not None and resolved["at"] is not None
+
+    def test_a_pick_still_drilling_down_references_nothing(self, mortise_and_tenon_frame):
+        # No feature reached yet, so there is nothing to measure to.
+        assert runner._pick_reference(None, "t#0", ["cut"], None, None, None) is None

--- a/tests/test_measurement_kinds.py
+++ b/tests/test_measurement_kinds.py
@@ -14,13 +14,16 @@ from pathlib import Path
 import pytest
 
 from kumiki.drawing import (
+    Measure,
     MeasurementDirection,
     MeasurementFeature,
     MeasurementKind,
     MeasurementOperation,
+    MeasurementPlacement,
     MeasurementSpace,
     kinds_for,
 )
+from kumiki.identity import FeatureRef, ResolvedTimberPath, SingleFeaturePath
 
 DISTANCE = MeasurementOperation.DISTANCE
 ANGLE = MeasurementOperation.ANGLE
@@ -147,3 +150,120 @@ class TestTheViewerAgrees:
         }
 
         assert self._viewer_rules() == expected
+
+
+class TestAnchorsAreWrittenInOneOrder:
+    """Measuring A to B and measuring B to A are the same measurement."""
+
+    def _anchor(self, name):
+        return SingleFeaturePath(
+            ResolvedTimberPath("post"), FeatureRef((name,), name), "FACE")
+
+    def test_the_pair_comes_out_the_same_way_round(self):
+        first, second = self._anchor("aaa"), self._anchor("zzz")
+
+        forwards = Measure(first, second)
+        backwards = Measure(second, first)
+
+        assert forwards.anchor_a.feature == backwards.anchor_a.feature
+        assert forwards == backwards
+
+    def test_it_is_one_measurement_however_it_was_written(self):
+        # Without this a pair written both ways is two entries in a viewport,
+        # two dimensions drawn on top of each other, and a file override that
+        # matches neither.
+        first, second = self._anchor("aaa"), self._anchor("zzz")
+
+        assert Measure(first, second).identity() == Measure(second, first).identity()
+
+    def test_swapping_keeps_the_dimension_on_the_same_side(self):
+        # The offset is perpendicular to the run between the anchors, so
+        # reversing the run reverses the side. The offset is signed, so
+        # negating it puts the line back.
+        first, second = self._anchor("aaa"), self._anchor("zzz")
+
+        swapped = Measure(second, first, placement=MeasurementPlacement(offset=-24.0))
+
+        assert swapped.placement.offset == 24.0
+
+    def test_an_order_that_is_already_canonical_is_left_alone(self):
+        first, second = self._anchor("aaa"), self._anchor("zzz")
+
+        kept = Measure(first, second, placement=MeasurementPlacement(offset=-24.0))
+
+        assert kept.anchor_a.feature == "aaa"
+        assert kept.placement.offset == -24.0
+
+    def test_no_placement_is_fine(self):
+        first, second = self._anchor("aaa"), self._anchor("zzz")
+
+        assert Measure(second, first).placement is None
+
+
+class TestKindTellsTwoMeasurementsApart:
+    """Two kinds between one pair are two dimensions, and both should show."""
+
+    def _anchor(self, name):
+        return SingleFeaturePath(
+            ResolvedTimberPath("post"), FeatureRef((name,), name), "FACE")
+
+    def _pair(self):
+        return self._anchor("aaa"), self._anchor("zzz")
+
+    def test_the_horizontal_and_the_vertical_are_not_the_same_measurement(self):
+        # The ordinary thing to want between two points, without having to mint
+        # an id to say they are different.
+        first, second = self._pair()
+
+        across = Measure(first, second, kind="horizontal")
+        up = Measure(first, second, kind="vertical")
+
+        assert across.identity() != up.identity()
+
+    def test_the_same_kind_written_twice_is_one_measurement(self):
+        first, second = self._pair()
+
+        assert (Measure(first, second, kind="horizontal").identity()
+                == Measure(second, first, kind="horizontal").identity())
+
+    def test_an_older_name_matches_the_kind_it_became(self):
+        # A file written before kinds had structure has to keep overriding the
+        # code measurement it always overrode.
+        first, second = self._pair()
+        older = Measure(first, second, kind="angle")
+        newer = Measure(first, second,
+                        kind={"operation": "angle", "space": "projected",
+                              "direction": "perpendicular"})
+
+        assert older.identity() == newer.identity()
+
+    def test_asking_for_no_kind_is_its_own_measurement(self):
+        # "Whichever is natural" is a different request from naming one, even
+        # when the viewport would resolve it to the same thing.
+        first, second = self._pair()
+
+        assert Measure(first, second).identity() != Measure(
+            first, second, kind="horizontal").identity()
+
+    def test_the_viewer_and_the_library_build_the_same_identity(self):
+        # A file measurement overrides a code one by matching this tuple, so
+        # the two sides have to agree on what it is.
+        import importlib.util
+        import sys
+
+        runner_path = Path(__file__).resolve().parent.parent / "kigumi" / "runner.py"
+        spec = importlib.util.spec_from_file_location("kigumi_runner_kinds", runner_path)
+        runner = importlib.util.module_from_spec(spec)
+        sys.modules["kigumi_runner_kinds"] = runner
+        spec.loader.exec_module(runner)
+
+        first, second = self._pair()
+        measure = Measure(first, second, kind="horizontal")
+        on_the_wire = {
+            "a": runner.serialize_feature_path(measure.anchor_a),
+            "b": runner.serialize_feature_path(measure.anchor_b),
+            "kind": measure.kind.as_wire(),
+            "measureId": None,
+        }
+
+        assert runner._measure_identity(on_the_wire) == measure.identity()

--- a/tests/test_measurement_kinds.py
+++ b/tests/test_measurement_kinds.py
@@ -20,7 +20,9 @@ from kumiki.drawing import (
     MeasurementKind,
     MeasurementOperation,
     MeasurementPlacement,
+    MeasurementSource,
     MeasurementSpace,
+    does_override,
     kinds_for,
 )
 from kumiki.identity import FeatureRef, ResolvedTimberPath, SingleFeaturePath
@@ -267,3 +269,56 @@ class TestKindTellsTwoMeasurementsApart:
         }
 
         assert runner._measure_identity(on_the_wire) == measure.identity()
+
+
+class TestWhatReplacesWhat:
+    """Three tiers: an algorithm proposes, code decides, the file has the last word."""
+
+    GENERATED = MeasurementSource.PYTHON_GENERATED
+    CODED = MeasurementSource.PYTHON_CODED
+    FILE = MeasurementSource.FILE_OVERRIDE
+
+    def _anchor(self, name):
+        return SingleFeaturePath(
+            ResolvedTimberPath("post"), FeatureRef((name,), name), "FACE")
+
+    def _measure(self, kind=None):
+        return Measure(self._anchor("aaa"), self._anchor("zzz"), kind=kind)
+
+    def test_a_file_override_must_match_the_kind_too(self):
+        # It was written against a particular dimension. The vertical between
+        # the same two features is one it was never about.
+        across = self._measure("horizontal")
+        up = self._measure("vertical")
+
+        assert does_override(across, across, self.FILE, self.CODED)
+        assert not does_override(up, across, self.FILE, self.CODED)
+
+    def test_code_overrules_an_algorithm_whatever_kind_it_chose(self):
+        # Otherwise you would have to guess the generated kind to replace it,
+        # which stops working the next time the algorithm changes.
+        across = self._measure("horizontal")
+        up = self._measure("vertical")
+
+        assert does_override(up, across, self.CODED, self.GENERATED)
+
+    def test_a_different_pair_is_never_the_same_measurement(self):
+        one = self._measure("horizontal")
+        other = Measure(self._anchor("aaa"), self._anchor("mmm"), kind="horizontal")
+
+        assert not does_override(other, one, self.FILE, self.CODED)
+        assert not does_override(other, one, self.CODED, self.GENERATED)
+
+    def test_two_of_the_same_tier_sit_beside_each_other(self):
+        # However alike. Two coded measurements are two measurements.
+        measure = self._measure("horizontal")
+
+        assert not does_override(measure, measure, self.CODED, self.CODED)
+        assert not does_override(measure, measure, self.FILE, self.FILE)
+
+    def test_a_lower_tier_never_displaces_a_higher_one(self):
+        measure = self._measure("horizontal")
+
+        assert not does_override(measure, measure, self.CODED, self.FILE)
+        assert not does_override(measure, measure, self.GENERATED, self.FILE)
+        assert not does_override(measure, measure, self.GENERATED, self.CODED)


### PR DESCRIPTION
Three pieces, none wired to the viewer yet. Each stands alone and is tested on its own.

## A pick hands back a measurement reference

`_pick_reference` gives back what a measurement would hold — a `SingleFeaturePath` for a face, a `DerivedFeaturePath` for a derived edge.

Only the runner can build this: a path means nothing without the CSG it is read against, and a derived edge is not among anyone's declared features, so it has to name the two faces that form it instead.

Tested through the round trip that matters — what a pick writes down, `resolve_anchor` finds again.

## MeasurementPlacement

Where a dimension sits, as distinct from what it measures. `offset` is the only field it has yet; it is an object rather than a bare number because placement grows into side, text position and witness lines.

Deliberately **outside identity** — moving a dimension line is not measuring something else.

While here: `kind` was not being serialized on a measurement at all. Both `kind` and `placement` now travel, so overriding a code measurement in the file starts from what the code asked for rather than losing it.

## The pick state machine

`measure-mode.js`, with no DOM, scene or runner, so the awkward part is readable in one place and testable without a viewer. States written out at the top of the file:

| state | input | goes to | and |
|---|---|---|---|
| OFF | pick A | FROM | A is held |
| FROM | pick B | BETWEEN | the measurement A-B is made |
| FROM | escape | OFF | A released, mode left |
| BETWEEN | pick C | BETWEEN | B replaced by C; the **same** measurement now reads A-C |
| BETWEEN | escape | FROM | B released, measurement removed, A kept |
| any | leave | OFF | everything released |

One measurement in flight: the second pick makes it and every pick after edits it. So measuring the same pair twice cannot happen by accident, and no id has to be minted to tell two apart. Escape pops one end, which is why leaving takes two from BETWEEN.

## Two things not specified, worth a look

- **Measuring a feature to itself is refused** (`same-feature`), staying in FROM. It measures nothing.
- **Refusals carry a reason** rather than doing nothing — `no-feature` while a click is still drilling through compounds — so the caller has something to print.

## Not in this PR

The wiring: routing picks through the mode inside a drawing, clearing feature and measurement selection when the mode changes, printing refusals, and writing the measurement into the file. Then editing, and delete via the `suppressed` flag that already exists.

## Note on the history

This work went to `main` first, which left nothing to open a PR against, and `main` cannot be force-pushed. Commit `08fa73c` on main reverts it; this branch re-applies it. The diff here is the work itself.

## Tests

`1357` pytest, `555` jest (up 17), extension `13/13`.