### PR TITLE
Hover: show what a click would take, and make picking 4x faster

### DIFF
--- a/kigumi/__tests__/hover-state.test.js
+++ b/kigumi/__tests__/hover-state.test.js
@@ -1,4 +1,4 @@
-const { HoverState } = require('../webview/hover-state.js');
+const { HoverState, hoverTarget } = require('../webview/hover-state.js');
 
 function answer(feature, path = ['cut'], memberKey = 'post#0') {
     return { memberKey, path, feature };
@@ -109,5 +109,31 @@ describe('telling two answers apart', () => {
     it('nothing matches nothing', () => {
         expect(HoverState.sameFeature(null, null)).toBe(true);
         expect(HoverState.sameFeature(answer('a'), null)).toBe(false);
+    });
+});
+
+
+describe('what to ask about', () => {
+    // A ray hit is {memberKey, hit}, and the inner hit carries the point. Two
+    // nested things both reasonably called "hit" -- reaching for the wrong one
+    // threw inside the render loop and froze the view, so it is pinned here.
+    const hit = (memberKey, x, y, z) => ({ memberKey, hit: { point: { x, y, z } } });
+
+    it('takes the frontmost hit and its world point', () => {
+        expect(hoverTarget([hit('post#0', 1, 2, 3), hit('post#1', 9, 9, 9)])).toEqual({
+            memberKey: 'post#0',
+            point: [1, 2, 3],
+        });
+    });
+
+    it('nothing under the pointer is nothing to ask', () => {
+        expect(hoverTarget([])).toBeNull();
+        expect(hoverTarget(null)).toBeNull();
+    });
+
+    it('a hit without a point is not asked about either', () => {
+        // Rather than reading undefined off it, which is what threw.
+        expect(hoverTarget([{ memberKey: 'post#0' }])).toBeNull();
+        expect(hoverTarget([{ memberKey: 'post#0', hit: {} }])).toBeNull();
     });
 });

--- a/kigumi/__tests__/hover-state.test.js
+++ b/kigumi/__tests__/hover-state.test.js
@@ -20,33 +20,54 @@ describe('hover pacing', () => {
         expect(result.reason).toBe('barely-moved');
     });
 
-    it('nothing is asked until a frame has passed without moving', () => {
+    it('asks straight away, with nothing to wait for', () => {
         const hover = new HoverState();
         hover.moved(100, 100);
 
-        expect(hover.due()).toBeNull();
         expect(hover.due()).not.toBeNull();
     });
 
-    it('a pointer that keeps moving asks nothing on the way past', () => {
-        // Every frame of a sweep has a move in it, so the still frame never
-        // arrives until the sweep stops.
+    it('asks nothing more while a question is still out', () => {
+        // Answering is not parallel: the requests go to one runner over a pipe.
+        // Firing per frame regardless would build a queue answered long after
+        // the pointer has gone.
         const hover = new HoverState();
         hover.moved(100, 100);
         hover.due();
-        hover.moved(200, 100);
-        hover.due();
-        hover.moved(300, 100);
 
+        hover.moved(200, 100);
+
+        expect(hover.due()).toBeNull();
+    });
+
+    it('asks again as soon as the answer arrives', () => {
+        const hover = new HoverState();
+        hover.moved(100, 100);
+        const first = hover.due();
+        hover.answered(first.request, answer('a'));
+
+        hover.moved(200, 100);
+
+        expect(hover.due()).not.toBeNull();
+    });
+
+    it('gives up on a question that never comes back', () => {
+        // Otherwise one failure leaves hover silent for the rest of the session.
+        const hover = new HoverState({ abandonAfter: 3 });
+        hover.moved(100, 100);
+        hover.due();
+        hover.moved(200, 100);
+
+        expect(hover.due()).toBeNull();
         expect(hover.due()).toBeNull();
         expect(hover.due()).not.toBeNull();
     });
 
     it('asks about where the pointer ended up, not where it began', () => {
+        // Several moves can land in one frame; only the last is worth asking.
         const hover = new HoverState();
         hover.moved(100, 100);
         hover.moved(300, 200);
-        hover.due();
 
         const due = hover.due();
 
@@ -54,7 +75,7 @@ describe('hover pacing', () => {
     });
 
     it('an answer to the current question is kept', () => {
-        const hover = new HoverState({ settleFrames: 0 });
+        const hover = new HoverState();
         hover.moved(100, 100);
         const due = hover.due();
 
@@ -65,9 +86,9 @@ describe('hover pacing', () => {
     });
 
     it('an answer overtaken by a newer question is dropped', () => {
-        // The normal case, not an edge one: the pointer keeps moving while the
-        // runner is working, and the old answer is about a place it has left.
-        const hover = new HoverState({ settleFrames: 0 });
+        // Reachable once a question has been abandoned and asked again: the
+        // late answer is about a place the pointer has long left.
+        const hover = new HoverState({ abandonAfter: 1 });
         hover.moved(100, 100);
         const first = hover.due();
         hover.moved(400, 400);
@@ -80,8 +101,32 @@ describe('hover pacing', () => {
         expect(hover.feature).toBeNull();
     });
 
+    it('settling can be asked for, and is off by default', () => {
+        // Zero asks the frame the pointer moves. A larger number trades
+        // responsiveness for fewer questions.
+        expect(new HoverState().due()).toBeNull();
+
+        const patient = new HoverState({ settleFrames: 2 });
+        patient.moved(100, 100);
+
+        expect(patient.due()).toBeNull();
+        expect(patient.due()).toBeNull();
+        expect(patient.due()).not.toBeNull();
+    });
+
+    it('a move restarts the settling', () => {
+        const patient = new HoverState({ settleFrames: 2 });
+        patient.moved(100, 100);
+        patient.due();
+        patient.moved(300, 100);
+
+        expect(patient.due()).toBeNull();
+        expect(patient.due()).toBeNull();
+        expect(patient.due()).not.toBeNull();
+    });
+
     it('clearing forgets what was under the pointer', () => {
-        const hover = new HoverState({ settleFrames: 0 });
+        const hover = new HoverState();
         hover.moved(100, 100);
         hover.answered(hover.due().request, answer('mortise_right'));
 

--- a/kigumi/__tests__/hover-state.test.js
+++ b/kigumi/__tests__/hover-state.test.js
@@ -1,0 +1,113 @@
+const { HoverState } = require('../webview/hover-state.js');
+
+function answer(feature, path = ['cut'], memberKey = 'post#0') {
+    return { memberKey, path, feature };
+}
+
+describe('hover pacing', () => {
+    it('holds nothing to begin with', () => {
+        expect(new HoverState().feature).toBeNull();
+    });
+
+    it('a move that has barely travelled is not worth asking about', () => {
+        const hover = new HoverState();
+        hover.moved(100, 100, 0);
+        hover.due(1000);
+
+        const result = hover.moved(101, 100, 1000);
+
+        expect(result.ask).toBe(false);
+        expect(result.reason).toBe('barely-moved');
+    });
+
+    it('nothing is asked until the pointer settles', () => {
+        const hover = new HoverState({ settle: 40 });
+        hover.moved(100, 100, 0);
+
+        expect(hover.due(20)).toBeNull();
+        expect(hover.due(40)).not.toBeNull();
+    });
+
+    it('a pointer that keeps moving keeps resetting the wait', () => {
+        // Otherwise a sweep across the model would fire a question per step.
+        const hover = new HoverState({ settle: 40 });
+        hover.moved(100, 100, 0);
+        hover.moved(200, 100, 30);
+        hover.moved(300, 100, 60);
+
+        expect(hover.due(80)).toBeNull();
+        expect(hover.due(100)).not.toBeNull();
+    });
+
+    it('asks about where the pointer ended up, not where it began', () => {
+        const hover = new HoverState({ settle: 40 });
+        hover.moved(100, 100, 0);
+        hover.moved(300, 200, 10);
+
+        const due = hover.due(60);
+
+        expect([due.x, due.y]).toEqual([300, 200]);
+    });
+
+    it('an answer to the current question is kept', () => {
+        const hover = new HoverState({ settle: 0 });
+        hover.moved(100, 100, 0);
+        const due = hover.due(10);
+
+        const result = hover.answered(due.request, answer('mortise_right'));
+
+        expect(result.kept).toBe(true);
+        expect(hover.feature.feature).toBe('mortise_right');
+    });
+
+    it('an answer overtaken by a newer question is dropped', () => {
+        // The normal case, not an edge one: the pointer keeps moving while the
+        // runner is working, and the old answer is about a place it has left.
+        const hover = new HoverState({ settle: 0 });
+        hover.moved(100, 100, 0);
+        const first = hover.due(10);
+        hover.moved(400, 400, 20);
+        hover.due(30);
+
+        const result = hover.answered(first.request, answer('stale_feature'));
+
+        expect(result.kept).toBe(false);
+        expect(result.reason).toBe('stale');
+        expect(hover.feature).toBeNull();
+    });
+
+    it('clearing forgets what was under the pointer', () => {
+        const hover = new HoverState({ settle: 0 });
+        hover.moved(100, 100, 0);
+        hover.answered(hover.due(10).request, answer('mortise_right'));
+
+        expect(hover.clear().cleared).toBe(true);
+        expect(hover.feature).toBeNull();
+    });
+
+    it('clearing nothing says so', () => {
+        expect(new HoverState().clear().cleared).toBe(false);
+    });
+});
+
+describe('telling two answers apart', () => {
+    it('the same feature on the same node is the same answer', () => {
+        expect(HoverState.sameFeature(answer('a'), answer('a'))).toBe(true);
+    });
+
+    it('the same name on a different node is not', () => {
+        expect(HoverState.sameFeature(answer('a', ['one']), answer('a', ['two']))).toBe(false);
+    });
+
+    it('the same name on a different timber is not', () => {
+        expect(HoverState.sameFeature(
+            answer('a', ['cut'], 'post#0'),
+            answer('a', ['cut'], 'post#1'),
+        )).toBe(false);
+    });
+
+    it('nothing matches nothing', () => {
+        expect(HoverState.sameFeature(null, null)).toBe(true);
+        expect(HoverState.sameFeature(answer('a'), null)).toBe(false);
+    });
+});

--- a/kigumi/__tests__/hover-state.test.js
+++ b/kigumi/__tests__/hover-state.test.js
@@ -11,8 +11,8 @@ describe('hover pacing', () => {
 
     it('a move that has barely travelled is not worth asking about', () => {
         const hover = new HoverState();
-        hover.moved(100, 100, 0);
-        hover.due(1000);
+        hover.moved(100, 100);
+        hover.due();
 
         const result = hover.moved(101, 100, 1000);
 
@@ -20,39 +20,43 @@ describe('hover pacing', () => {
         expect(result.reason).toBe('barely-moved');
     });
 
-    it('nothing is asked until the pointer settles', () => {
-        const hover = new HoverState({ settle: 40 });
-        hover.moved(100, 100, 0);
+    it('nothing is asked until a frame has passed without moving', () => {
+        const hover = new HoverState();
+        hover.moved(100, 100);
 
-        expect(hover.due(20)).toBeNull();
-        expect(hover.due(40)).not.toBeNull();
+        expect(hover.due()).toBeNull();
+        expect(hover.due()).not.toBeNull();
     });
 
-    it('a pointer that keeps moving keeps resetting the wait', () => {
-        // Otherwise a sweep across the model would fire a question per step.
-        const hover = new HoverState({ settle: 40 });
-        hover.moved(100, 100, 0);
-        hover.moved(200, 100, 30);
-        hover.moved(300, 100, 60);
+    it('a pointer that keeps moving asks nothing on the way past', () => {
+        // Every frame of a sweep has a move in it, so the still frame never
+        // arrives until the sweep stops.
+        const hover = new HoverState();
+        hover.moved(100, 100);
+        hover.due();
+        hover.moved(200, 100);
+        hover.due();
+        hover.moved(300, 100);
 
-        expect(hover.due(80)).toBeNull();
-        expect(hover.due(100)).not.toBeNull();
+        expect(hover.due()).toBeNull();
+        expect(hover.due()).not.toBeNull();
     });
 
     it('asks about where the pointer ended up, not where it began', () => {
-        const hover = new HoverState({ settle: 40 });
-        hover.moved(100, 100, 0);
-        hover.moved(300, 200, 10);
+        const hover = new HoverState();
+        hover.moved(100, 100);
+        hover.moved(300, 200);
+        hover.due();
 
-        const due = hover.due(60);
+        const due = hover.due();
 
         expect([due.x, due.y]).toEqual([300, 200]);
     });
 
     it('an answer to the current question is kept', () => {
-        const hover = new HoverState({ settle: 0 });
-        hover.moved(100, 100, 0);
-        const due = hover.due(10);
+        const hover = new HoverState({ settleFrames: 0 });
+        hover.moved(100, 100);
+        const due = hover.due();
 
         const result = hover.answered(due.request, answer('mortise_right'));
 
@@ -63,11 +67,11 @@ describe('hover pacing', () => {
     it('an answer overtaken by a newer question is dropped', () => {
         // The normal case, not an edge one: the pointer keeps moving while the
         // runner is working, and the old answer is about a place it has left.
-        const hover = new HoverState({ settle: 0 });
-        hover.moved(100, 100, 0);
-        const first = hover.due(10);
-        hover.moved(400, 400, 20);
-        hover.due(30);
+        const hover = new HoverState({ settleFrames: 0 });
+        hover.moved(100, 100);
+        const first = hover.due();
+        hover.moved(400, 400);
+        hover.due();
 
         const result = hover.answered(first.request, answer('stale_feature'));
 
@@ -77,9 +81,9 @@ describe('hover pacing', () => {
     });
 
     it('clearing forgets what was under the pointer', () => {
-        const hover = new HoverState({ settle: 0 });
-        hover.moved(100, 100, 0);
-        hover.answered(hover.due(10).request, answer('mortise_right'));
+        const hover = new HoverState({ settleFrames: 0 });
+        hover.moved(100, 100);
+        hover.answered(hover.due().request, answer('mortise_right'));
 
         expect(hover.clear().cleared).toBe(true);
         expect(hover.feature).toBeNull();
@@ -125,21 +129,21 @@ describe('what to ask about', () => {
     // threw inside the render loop and froze the view, so it is pinned here.
     const hit = (memberKey, x, y, z) => ({ memberKey, hit: { point: { x, y, z } } });
 
-    it('takes the frontmost hit and its world point', () => {
-        expect(hoverTarget([hit('post#0', 1, 2, 3), hit('post#1', 9, 9, 9)])).toEqual({
+    it('takes the member the click decided on, and its world point', () => {
+        expect(hoverTarget(hit('post#0', 1, 2, 3))).toEqual({
             memberKey: 'post#0',
             point: [1, 2, 3],
         });
     });
 
-    it('nothing under the pointer is nothing to ask', () => {
-        expect(hoverTarget([])).toBeNull();
+    it('nothing decided is nothing to ask', () => {
         expect(hoverTarget(null)).toBeNull();
+        expect(hoverTarget({ action: 'clear' })).toBeNull();
     });
 
-    it('a hit without a point is not asked about either', () => {
+    it('a decision without a point is not asked about either', () => {
         // Rather than reading undefined off it, which is what threw.
-        expect(hoverTarget([{ memberKey: 'post#0' }])).toBeNull();
-        expect(hoverTarget([{ memberKey: 'post#0', hit: {} }])).toBeNull();
+        expect(hoverTarget({ memberKey: 'post#0' })).toBeNull();
+        expect(hoverTarget({ memberKey: 'post#0', hit: {} })).toBeNull();
     });
 });

--- a/kigumi/__tests__/hover-state.test.js
+++ b/kigumi/__tests__/hover-state.test.js
@@ -1,7 +1,7 @@
 const { HoverState, hoverTarget } = require('../webview/hover-state.js');
 
-function answer(feature, path = ['cut'], memberKey = 'post#0') {
-    return { memberKey, path, feature };
+function answer(featureLabel, path = ['cut'], memberKey = 'post#0') {
+    return { memberKey, path, featureLabel };
 }
 
 describe('hover pacing', () => {
@@ -57,7 +57,7 @@ describe('hover pacing', () => {
         const result = hover.answered(due.request, answer('mortise_right'));
 
         expect(result.kept).toBe(true);
-        expect(hover.feature.feature).toBe('mortise_right');
+        expect(hover.feature.featureLabel).toBe('mortise_right');
     });
 
     it('an answer overtaken by a newer question is dropped', () => {
@@ -97,6 +97,12 @@ describe('telling two answers apart', () => {
 
     it('the same name on a different node is not', () => {
         expect(HoverState.sameFeature(answer('a', ['one']), answer('a', ['two']))).toBe(false);
+    });
+
+    it('two faces of one prism are told apart', () => {
+        // Same path, different face. Comparing paths alone would leave the
+        // first drawn while the pointer sits on the second.
+        expect(HoverState.sameFeature(answer('left'), answer('right'))).toBe(false);
     });
 
     it('the same name on a different timber is not', () => {

--- a/kigumi/frame-view-session.js
+++ b/kigumi/frame-view-session.js
@@ -308,11 +308,16 @@ class FrameViewSession {
                 return;
             }
             if (message.type === 'hoverFeatureAtPoint') {
-                // Deliberately quiet on failure: this fires while the pointer
-                // moves, so a broken hover would fill the log rather than say
-                // anything useful, and there is nothing the user asked for to
-                // report back on.
-                this._handleHoverFeatureAtPoint(message).catch(() => {});
+                // Reported once and then not again. This fires while the
+                // pointer moves, so logging every failure would bury the log --
+                // but logging none of them is how a hover that never worked
+                // looked exactly like a hover that found nothing.
+                this._handleHoverFeatureAtPoint(message).catch((err) => {
+                    if (!this._hoverErrorReported) {
+                        this._hoverErrorReported = true;
+                        this.log(`[hover] ${err.message || err} (further hover errors are not logged)`);
+                    }
+                });
                 return;
             }
             if (message.type === 'requestDrawings') {

--- a/kigumi/frame-view-session.js
+++ b/kigumi/frame-view-session.js
@@ -307,6 +307,14 @@ class FrameViewSession {
                 });
                 return;
             }
+            if (message.type === 'hoverFeatureAtPoint') {
+                // Deliberately quiet on failure: this fires while the pointer
+                // moves, so a broken hover would fill the log rather than say
+                // anything useful, and there is nothing the user asked for to
+                // report back on.
+                this._handleHoverFeatureAtPoint(message).catch(() => {});
+                return;
+            }
             if (message.type === 'requestDrawings') {
                 this._handleDrawingsCommand('get_drawings', {}, { enter: false }).catch((err) => {
                     this.log(`[drawing] requestDrawings error: ${err.message || err}`);
@@ -960,6 +968,20 @@ class FrameViewSession {
         };
         const result = await this.runnerSession.slotRequest('find_csg_at_point', this.slotName, payload);
         this._postToWebview({ type: 'csgSelectionResult', ...result });
+    }
+
+    async _handleHoverFeatureAtPoint(message) {
+        if (!this.runnerSession) {
+            return;
+        }
+        const result = await this.runnerSession.slotRequest('hover_feature_at_point', this.slotName, {
+            memberKey: message.memberKey,
+            point: message.point,
+        });
+        // The request number goes out and comes back untouched, so the viewer
+        // can tell an answer about where the pointer is now from one about
+        // where it was two moves ago.
+        this._postToWebview({ type: 'hoverFeatureResult', request: message.request, ...result });
     }
 
     async _handleRequestCSGTree(message) {

--- a/kigumi/package.json
+++ b/kigumi/package.json
@@ -48,7 +48,7 @@
       "kigumi": [
         {
           "id": "kigumi.explorer",
-          "name": "Kigumi Explorer 🐙",
+          "name": "Kigumi Explorer 🦈",
           "icon": "templogo.png"
         }
       ]

--- a/kigumi/package.json
+++ b/kigumi/package.json
@@ -48,7 +48,7 @@
       "kigumi": [
         {
           "id": "kigumi.explorer",
-          "name": "Kigumi Explorer 🦀",
+          "name": "Kigumi Explorer 🐙",
           "icon": "templogo.png"
         }
       ]

--- a/kigumi/package.json
+++ b/kigumi/package.json
@@ -48,7 +48,7 @@
       "kigumi": [
         {
           "id": "kigumi.explorer",
-          "name": "Kigumi Explorer 🦈",
+          "name": "Kigumi Explorer 🐴",
           "icon": "templogo.png"
         }
       ]

--- a/kigumi/package.json
+++ b/kigumi/package.json
@@ -48,7 +48,7 @@
       "kigumi": [
         {
           "id": "kigumi.explorer",
-          "name": "Kigumi Explorer 🐴",
+          "name": "Kigumi Explorer 🦒",
           "icon": "templogo.png"
         }
       ]

--- a/kigumi/package.json
+++ b/kigumi/package.json
@@ -48,7 +48,7 @@
       "kigumi": [
         {
           "id": "kigumi.explorer",
-          "name": "Kigumi Explorer 🐢",
+          "name": "Kigumi Explorer 🦀",
           "icon": "templogo.png"
         }
       ]

--- a/kigumi/runner.py
+++ b/kigumi/runner.py
@@ -4081,145 +4081,25 @@ def _extract_highlight_mesh(
     return out_verts, out_idx, matched, total_tris
 
 
-def _feature_outline(feature: Any, node: Any, timber: Any, located: Any) -> Optional[List[List[float]]]:
-    """The shape of a feature, in world space, without touching the mesh.
-
-    A face comes back as the corners of its cropped region, an edge as the two
-    ends of its segment, a point as itself. All of it from the CSG, which is
-    what makes it cheap enough to run while the pointer moves: on a timber
-    where walking the mesh for a highlight takes 78ms, this takes 0.07ms.
-
-    APPROXIMATE, and not the same shape a click highlights. The click walks the
-    rendered mesh and gets the surface as it really is. This clips a plane by
-    half spaces, so it is convex by construction and cannot have a hole in it,
-    and csgconvexhull does not account for subtractions. Concretely: the front
-    face of a beam with eight mortises through it outlines as one rectangle the
-    length of the beam, with every mortise opening inside it.
-
-    Which is tolerable for what this is for. An outline of a face means its
-    outer boundary, and that is what this draws; the hole boundaries are
-    missing, not wrong. The identity is exact either way -- WHICH feature the
-    pointer is over comes from the same resolution a click uses, and only the
-    drawn shape approximates.
-
-    Where it would mislead is a face mostly cut away, which outlines at full
-    size. If that matters more than the 78ms, the answer is to walk the mesh
-    on a longer dwell and replace the outline once it arrives.
-
-    None when the feature cannot be placed -- a curved surface, a primitive
-    csgconvexhull cannot describe. The caller shows the name and draws nothing
-    rather than guessing an outline.
-    """
-    from kumiki.geometry import Line, Plane, Point
-    from kumiki.csgconvexhull import region_in_plane, segment_on_line
-
-    def to_world(points):
-        return [_vector3_to_floats(timber.transform.local_to_global(point)) for point in points]
-
-    if isinstance(located, Point):
-        return to_world([located.position])
-
-    solid = timber.get_perfect_timber_within_csg_local()
-    reach = float(timber.length) * 4
-    near = solid.transform.position
-
-    if isinstance(located, Plane):
-        region = region_in_plane(located, [node, solid], seed_reach=reach, near=near)
-        if region is None or region.is_empty:
-            return None
-        return to_world(region.boundary)
-
-    if isinstance(located, Line):
-        segment = segment_on_line(
-            located, [node, solid], seed_reach=reach, near=near,
-            tolerance=float(_edge_tolerance()),
-        )
-        if segment is None or segment.is_empty:
-            return None
-        return to_world(segment.ends)
-
-    return None
-
-
 def _handle_hover_feature_at_point(
     state: RunnerState, payload: Dict[str, Any], slot_state: Optional['SlotState'] = None,
 ) -> Dict[str, Any]:
-    """What is under the pointer, cheaply enough to ask while it is moving.
+    """What the pointer is over: the answer a click would give, without clicking.
 
-    The same resolution a click does, and none of the drawing. A click walks
-    every triangle of the timber to build a highlight mesh, which takes long
-    enough that asking it per mouse move would queue up faster than it could
-    answer. This resolves the feature and hands back its outline from the CSG
-    instead -- two orders of magnitude cheaper, and an outline is what a hover
-    should look like anyway: it says what you are about to click without
-    pretending to have selected it.
+    Deliberately the same code, not a cheaper likeness of it. An outline drawn
+    from the CSG was cheaper and was wrong in a way that showed: a face comes
+    back convex, so a timber face with mortises through it outlined as a whole
+    rectangle over the openings, and a face half cut away outlined at full size.
+    Hover exists to say what a click would take, so it has to be what a click
+    would take -- the same mesh, the same feature, the same drilling.
+
+    The viewer draws it in another colour and under the selection. That is the
+    entire difference.
+
+    Affordable because of when it is asked rather than how much it costs: the
+    pointer has to settle first, so this runs once per rest, not once per move.
     """
-    ss = slot_state if slot_state is not None else state._active
-    member_key = payload.get("memberKey")
-    point = payload.get("point")
-    eps = 5e-4
-
-    if not isinstance(member_key, str) or member_key not in ss.mesh_cache:
-        raise ValueError(f"Unknown memberKey: {member_key}")
-    if not isinstance(point, list) or len(point) != 3:
-        raise ValueError("point must be [x, y, z]")
-
-    cached = ss.mesh_cache[member_key]
-    local_csg = cached.get("local_csg")
-    cut_timber = cached.get("cut_timber")
-    if local_csg is None or cut_timber is None:
-        raise ValueError(f"No CSG data cached for {member_key}")
-
-    timber = cut_timber.timber
-    timber_rot, timber_pos = _build_inv_transform_float(timber.transform)
-    local_pt = _inv_transform_point(timber_rot, timber_pos, [float(p) for p in point])
-
-    started = time.monotonic()
-    new_path, target_csg, feature_label = _navigate_csg_to_leaf(local_csg, local_pt, eps)
-
-    feature_hits = _features_at_point(local_csg, local_pt, eps)
-    edge = _resolve_derived_edge(feature_hits) if feature_label is not None else None
-    feature_type = None
-    owner, node = None, target_csg
-    if edge is not None:
-        owned = _edge_owner(local_csg, edge)
-        if owned is not None:
-            node, new_path = owned[0], owned[1]
-        feature_label, feature_type, owner = edge.name, "EDGE", edge
-    elif feature_label is not None:
-        # The label a click resolves to is a declared feature's name where the
-        # node declares one, and a generic word -- "face", "cylindrical_surface"
-        # -- where it does not. Only the first can be outlined.
-        owner = next((hit.feature for hit in feature_hits
-                      if hit.feature.name == feature_label), None)
-        if owner is not None:
-            node = next((hit.owner for hit in feature_hits
-                         if hit.feature is owner), target_csg)
-
-    outline = None
-    if owner is not None:
-        located = owner.locate(node)
-        outline = _feature_outline(owner, node, timber, located)
-
-    described = _describe_pick(
-        target_csg, local_csg, cut_timber, local_pt, eps, feature_label, feature_type,
-    )
-
-    return {
-        "memberKey": member_key,
-        "path": new_path,
-        "feature": feature_label,
-        "featureType": described.get("featureType") or feature_type,
-        "nodeLabel": described.get("nodeLabel"),
-        "nodeDisplayName": described.get("nodeDisplayName"),
-        # What a measurement would hold, so the viewer can say whether this and
-        # whatever is already held could be measured -- before the click.
-        "reference": _pick_reference(
-            local_csg, member_key, new_path, feature_label, feature_type, edge,
-        ),
-        "outline": outline,
-        "elapsedMs": round((time.monotonic() - started) * 1000, 2),
-    }
+    return _handle_find_csg_at_point(state, payload, slot_state)
 
 
 def _handle_find_csg_at_point(state: RunnerState, payload: Dict[str, Any], slot_state: Optional['SlotState'] = None) -> Dict[str, Any]:

--- a/kigumi/runner.py
+++ b/kigumi/runner.py
@@ -4030,6 +4030,23 @@ def _feature_outline(feature: Any, node: Any, timber: Any, located: Any) -> Opti
     what makes it cheap enough to run while the pointer moves: on a timber
     where walking the mesh for a highlight takes 78ms, this takes 0.07ms.
 
+    APPROXIMATE, and not the same shape a click highlights. The click walks the
+    rendered mesh and gets the surface as it really is. This clips a plane by
+    half spaces, so it is convex by construction and cannot have a hole in it,
+    and csgconvexhull does not account for subtractions. Concretely: the front
+    face of a beam with eight mortises through it outlines as one rectangle the
+    length of the beam, with every mortise opening inside it.
+
+    Which is tolerable for what this is for. An outline of a face means its
+    outer boundary, and that is what this draws; the hole boundaries are
+    missing, not wrong. The identity is exact either way -- WHICH feature the
+    pointer is over comes from the same resolution a click uses, and only the
+    drawn shape approximates.
+
+    Where it would mislead is a face mostly cut away, which outlines at full
+    size. If that matters more than the 78ms, the answer is to walk the mesh
+    on a longer dwell and replace the outline once it arrives.
+
     None when the feature cannot be placed -- a curved surface, a primitive
     csgconvexhull cannot describe. The caller shows the name and draws nothing
     rather than guessing an outline.

--- a/kigumi/runner.py
+++ b/kigumi/runner.py
@@ -3064,7 +3064,7 @@ def make_ready_event(state: RunnerState) -> Dict[str, Any]:
         "examplePath": str(ss.file_path),
         "commands": [
             "ping", "reload_example", "get_frame", "get_geometry",
-            "get_member", "find_csg_at_point", "find_csg_by_path",
+            "get_member", "find_csg_at_point", "hover_feature_at_point", "find_csg_by_path",
             "get_layers_tree", "get_csg_tree",
             "get_default_drawing_for_debugging",
             "create_drawing_from_selection",
@@ -4022,6 +4022,130 @@ def _extract_highlight_mesh(
     return out_verts, out_idx, matched, total_tris
 
 
+def _feature_outline(feature: Any, node: Any, timber: Any, located: Any) -> Optional[List[List[float]]]:
+    """The shape of a feature, in world space, without touching the mesh.
+
+    A face comes back as the corners of its cropped region, an edge as the two
+    ends of its segment, a point as itself. All of it from the CSG, which is
+    what makes it cheap enough to run while the pointer moves: on a timber
+    where walking the mesh for a highlight takes 78ms, this takes 0.07ms.
+
+    None when the feature cannot be placed -- a curved surface, a primitive
+    csgconvexhull cannot describe. The caller shows the name and draws nothing
+    rather than guessing an outline.
+    """
+    from kumiki.geometry import Line, Plane, Point
+    from kumiki.csgconvexhull import region_in_plane, segment_on_line
+
+    def to_world(points):
+        return [_vector3_to_floats(timber.transform.local_to_global(point)) for point in points]
+
+    if isinstance(located, Point):
+        return to_world([located.position])
+
+    solid = timber.get_perfect_timber_within_csg_local()
+    reach = float(timber.length) * 4
+    near = solid.transform.position
+
+    if isinstance(located, Plane):
+        region = region_in_plane(located, [node, solid], seed_reach=reach, near=near)
+        if region is None or region.is_empty:
+            return None
+        return to_world(region.boundary)
+
+    if isinstance(located, Line):
+        segment = segment_on_line(
+            located, [node, solid], seed_reach=reach, near=near,
+            tolerance=float(_edge_tolerance()),
+        )
+        if segment is None or segment.is_empty:
+            return None
+        return to_world(segment.ends)
+
+    return None
+
+
+def _handle_hover_feature_at_point(
+    state: RunnerState, payload: Dict[str, Any], slot_state: Optional['SlotState'] = None,
+) -> Dict[str, Any]:
+    """What is under the pointer, cheaply enough to ask while it is moving.
+
+    The same resolution a click does, and none of the drawing. A click walks
+    every triangle of the timber to build a highlight mesh, which takes long
+    enough that asking it per mouse move would queue up faster than it could
+    answer. This resolves the feature and hands back its outline from the CSG
+    instead -- two orders of magnitude cheaper, and an outline is what a hover
+    should look like anyway: it says what you are about to click without
+    pretending to have selected it.
+    """
+    ss = slot_state if slot_state is not None else state._active
+    member_key = payload.get("memberKey")
+    point = payload.get("point")
+    eps = 5e-4
+
+    if not isinstance(member_key, str) or member_key not in ss.mesh_cache:
+        raise ValueError(f"Unknown memberKey: {member_key}")
+    if not isinstance(point, list) or len(point) != 3:
+        raise ValueError("point must be [x, y, z]")
+
+    cached = ss.mesh_cache[member_key]
+    local_csg = cached.get("local_csg")
+    cut_timber = cached.get("cut_timber")
+    if local_csg is None or cut_timber is None:
+        raise ValueError(f"No CSG data cached for {member_key}")
+
+    timber = cut_timber.timber
+    timber_rot, timber_pos = _build_inv_transform_float(timber.transform)
+    local_pt = _inv_transform_point(timber_rot, timber_pos, [float(p) for p in point])
+
+    started = time.monotonic()
+    new_path, target_csg, feature_label = _navigate_csg_to_leaf(local_csg, local_pt, eps)
+
+    feature_hits = _features_at_point(local_csg, local_pt, eps)
+    edge = _resolve_derived_edge(feature_hits) if feature_label is not None else None
+    feature_type = None
+    owner, node = None, target_csg
+    if edge is not None:
+        owned = _edge_owner(local_csg, edge)
+        if owned is not None:
+            node, new_path = owned[0], owned[1]
+        feature_label, feature_type, owner = edge.name, "EDGE", edge
+    elif feature_label is not None:
+        # The label a click resolves to is a declared feature's name where the
+        # node declares one, and a generic word -- "face", "cylindrical_surface"
+        # -- where it does not. Only the first can be outlined.
+        owner = next((hit.feature for hit in feature_hits
+                      if hit.feature.name == feature_label), None)
+        if owner is not None:
+            node = next((hit.owner for hit in feature_hits
+                         if hit.feature is owner), target_csg)
+
+    outline = None
+    if owner is not None:
+        located = owner.locate(node)
+        outline = _feature_outline(owner, node, timber, located)
+
+    described = _describe_pick(
+        target_csg, local_csg, cut_timber, local_pt, eps, feature_label, feature_type,
+    )
+
+    return {
+        "memberKey": member_key,
+        "path": new_path,
+        "feature": feature_label,
+        "featureType": described.get("featureType") or feature_type,
+        "nodeLabel": described.get("nodeLabel"),
+        "nodeDisplayName": described.get("nodeDisplayName"),
+        # What a measurement would hold, so the viewer can say whether this and
+        # whatever is already held could be measured -- before the click.
+        "reference": _pick_reference(
+            local_csg, member_key, new_path, feature_label, feature_type, edge,
+        ),
+        "outline": outline,
+        "elapsedMs": round((time.monotonic() - started) * 1000, 2),
+    }
+
+
 def _handle_find_csg_at_point(state: RunnerState, payload: Dict[str, Any], slot_state: Optional['SlotState'] = None) -> Dict[str, Any]:
     """Process a find_csg_at_point request and return the result dict."""
     ss = slot_state if slot_state is not None else state._active
@@ -4604,6 +4728,11 @@ def handle_request(state: RunnerState, request: Dict[str, Any]) -> tuple[RunnerS
         ss = _resolve_slot(state, payload)
         member_name = _require_str(payload, "name", "get_member requires payload.name")
         return state, make_success_response(request_id, command, get_member_result(ss.frame, member_name)), False
+
+    if command == "hover_feature_at_point":
+        ss = _resolve_slot(state, payload)
+        result = _handle_hover_feature_at_point(state, payload, ss)
+        return state, make_success_response(request_id, command, result), False
 
     if command == "find_csg_at_point":
         ss = _resolve_slot(state, payload)

--- a/kigumi/runner.py
+++ b/kigumi/runner.py
@@ -3938,6 +3938,56 @@ def _pick_reference(
     ))
 
 
+def _aabb_filter(csg: Any, eps: float):
+    """A cheap "could this point be on *csg*" test, or None if it cannot help.
+
+    None when the box says nothing useful -- a solid unbounded in every
+    direction, or one whose bounds cannot be read. An empty solid rejects
+    everything, which is a real answer rather than an unhelpful one.
+
+    The bounds are the CSG's own, so points must be in the same space it is:
+    timber-local, the same as the centroids the caller computes.
+    """
+    try:
+        with warnings.catch_warnings():
+            # Asking speculatively, and "unbounded" is a perfectly good answer:
+            # it means the box cannot help and the walk goes ahead unfiltered.
+            # The library's warning is for callers who wanted a real box.
+            warnings.simplefilter("ignore")
+            box = csg.get_aabb()
+    except Exception:
+        return None
+    if box is None:
+        return None
+    if getattr(box, "is_empty", False):
+        return lambda point: False
+
+    bounds = [
+        (box.min_x, box.max_x),
+        (box.min_y, box.max_y),
+        (box.min_z, box.max_z),
+    ]
+    limits = []
+    for low, high in bounds:
+        limits.append((
+            None if low is None else float(low) - eps,
+            None if high is None else float(high) + eps,
+        ))
+    if all(low is None and high is None for low, high in limits):
+        return None
+
+    def inside(point) -> bool:
+        for axis, (low, high) in enumerate(limits):
+            value = point[axis]
+            if low is not None and value < low:
+                return False
+            if high is not None and value > high:
+                return False
+        return True
+
+    return inside
+
+
 def _extract_highlight_mesh(
     mesh_vertices: List[float],
     mesh_indices: List[int],
@@ -3968,6 +4018,13 @@ def _extract_highlight_mesh(
         and len(selected_path) > 0
     )
 
+    # Broadphase: a triangle whose centroid is outside the target's own box
+    # cannot be on its boundary, and a box test is far cheaper than asking the
+    # CSG. It matters because the target is usually small and the mesh is the
+    # whole timber -- a mortise on a beam keeps 10 triangles out of 376, and the
+    # walk drops from 2.8ms to 0.1ms.
+    inside_box = _aabb_filter(target_csg, eps)
+
     for tri in range(total_tris):
         i0 = mesh_indices[tri * 3]
         i1 = mesh_indices[tri * 3 + 1]
@@ -3978,6 +4035,8 @@ def _extract_highlight_mesh(
         cz = (mesh_vertices[i0*3+2] + mesh_vertices[i1*3+2] + mesh_vertices[i2*3+2]) / 3.0
         # Convert centroid to timber-local
         local_c = _inv_transform_point(timber_rot, timber_pos, [cx, cy, cz])
+        if inside_box is not None and not inside_box(local_c):
+            continue
         if _csg_point_on_boundary(target_csg, local_c, eps):
             if enforce_owner:
                 owner = _resolve_csg_at_path(root_csg, selected_path, local_c, eps)

--- a/kigumi/runner.py
+++ b/kigumi/runner.py
@@ -4000,6 +4000,7 @@ def _extract_highlight_mesh(
     selected_ref: Optional[Any] = None,
     feature_label: Optional[str] = None,
     edge_feature: Optional[Any] = None,
+    feature_type: Optional[str] = None,
 ) -> Tuple[List[float], List[int], int, int]:
     """Extract triangles belonging to *target_csg* from the rendered mesh.
 
@@ -4023,7 +4024,26 @@ def _extract_highlight_mesh(
     # CSG. It matters because the target is usually small and the mesh is the
     # whole timber -- a mortise on a beam keeps 10 triangles out of 376, and the
     # walk drops from 2.8ms to 0.1ms.
+    # An edge whose line has already been worked out has no triangles to light:
+    # the line IS its highlight. Without this the walk still runs, comparing
+    # every triangle against an edge's name that no face can ever answer to, and
+    # spends a fifth of a second arriving at nothing.
+    if feature_type == "EDGE" and edge_feature is None:
+        return [], [], 0, len(mesh_indices) // 3
+
     inside_box = _aabb_filter(target_csg, eps)
+
+    # The feature we are matching against, looked up once instead of once per
+    # triangle. _detect_face_label asks the node for EVERY feature at the point
+    # and compares names; when the name is a declared feature we can ask that
+    # one feature directly, which is the same answer without the search.
+    #
+    # test_point is only meaningful for a point already known to be on the
+    # owner's boundary -- which the loop below establishes before it gets here.
+    wanted_feature = None
+    if feature_label is not None and edge_feature is None:
+        wanted_feature = next(
+            (f for f in target_csg.get_declared_features() if f.name == feature_label), None)
 
     for tri in range(total_tris):
         i0 = mesh_indices[tri * 3]
@@ -4067,7 +4087,12 @@ def _extract_highlight_mesh(
                         on_edge += 1
                 if on_edge < 2:
                     continue
+            elif wanted_feature is not None:
+                if not wanted_feature.test_point(target_csg, _to_v3(local_c), eps):
+                    continue
             elif feature_label is not None:
+                # A generic name -- "left", "cylindrical_surface" -- which no
+                # declared feature answers to, so it has to be worked out.
                 tri_face_label = _detect_face_label(target_csg, local_c, eps)
                 if tri_face_label != feature_label:
                     continue
@@ -4189,6 +4214,7 @@ def _handle_find_csg_at_point(state: RunnerState, payload: Dict[str, Any], slot_
         selected_ref=parent_csg if feature_label is not None else target_csg,
         feature_label=feature_label,
         edge_feature=edge if (highlight_edge is None and not edge_absent) else None,
+        feature_type=feature_type,
     )
 
     # When a feature (face) is selected, also extract the parent labeled CSG mesh

--- a/kigumi/viewer.js
+++ b/kigumi/viewer.js
@@ -152,6 +152,8 @@ function getWebviewContent(webview, frameData, geometryData, profiling, uiState 
     const sceneManagerJsUri = webview.asWebviewUri(vscode.Uri.file(path.join(webviewDir, 'scene-manager.js'))).toString();
     const inputControllerJsUri = webview.asWebviewUri(vscode.Uri.file(path.join(webviewDir, 'input-controller.js'))).toString();
     const measurementsJsUri = webview.asWebviewUri(vscode.Uri.file(path.join(webviewDir, 'measurements.js'))).toString();
+    const hoverStateJsUri = webview.asWebviewUri(vscode.Uri.file(path.join(webviewDir, 'hover-state.js'))).toString();
+    const measureModeJsUri = webview.asWebviewUri(vscode.Uri.file(path.join(webviewDir, 'measure-mode.js'))).toString();
     const drawingPanelJsUri = webview.asWebviewUri(vscode.Uri.file(path.join(webviewDir, 'drawing-panel.js'))).toString();
     const geometryModeJsUri = webview.asWebviewUri(vscode.Uri.file(path.join(webviewDir, 'geometry-mode.js'))).toString();
     const csgTreeViewJsUri = webview.asWebviewUri(vscode.Uri.file(path.join(webviewDir, 'csg-tree-view.js'))).toString();
@@ -204,6 +206,8 @@ function getWebviewContent(webview, frameData, geometryData, profiling, uiState 
         .replace('__SCENE_MANAGER_JS_URI__', sceneManagerJsUri)
         .replace('__INPUT_CONTROLLER_JS_URI__', inputControllerJsUri)
         .replace('__MEASUREMENTS_JS_URI__', measurementsJsUri)
+        .replace('__HOVER_STATE_JS_URI__', hoverStateJsUri)
+        .replace('__MEASURE_MODE_JS_URI__', measureModeJsUri)
         .replace('__DRAWING_PANEL_JS_URI__', drawingPanelJsUri)
         .replace('__GEOMETRY_MODE_JS_URI__', geometryModeJsUri)
         .replace('__CSG_TREE_VIEW_JS_URI__', csgTreeViewJsUri)

--- a/kigumi/webview/hover-state.js
+++ b/kigumi/webview/hover-state.js
@@ -20,22 +20,35 @@
     // affordable, but not free, so this also:
     //
     //   - ignores a move that has not travelled far enough to mean anything,
-    //   - waits for one still frame, so a sweep asks nothing on the way past,
+    //   - asks nothing while a question is still out, so a sweep cannot queue
+    //     up hundreds of them and answer them all after the pointer has gone,
     //   - keeps only the newest answer, since an older one is about a place the
     //     pointer has already left.
+    //
+    // There is no delay before asking. A wait long enough to be worth having is
+    // long enough to feel, and the question is cheap enough not to need one --
+    // what paces it is the answer coming back, which is the honest limit.
 
     /** Below this the pointer has not really moved, in canvas pixels. */
     const MOVE_SLOP_PX = 3;
 
     /**
-     * A pointer is settled once a frame has passed without it moving.
+     * Frames of stillness before asking. Zero asks the frame the pointer moves.
      *
-     * Not a wait measured in milliseconds: any number long enough to be worth
-     * having is long enough to feel. One still frame is the shortest thing
-     * that means "stopped", and it costs nothing when the pointer is sweeping,
-     * since every frame of a sweep has a move in it.
+     * Zero is the default because the question is cheap and the answer paces
+     * itself -- see due(). Raise it to trade responsiveness for fewer
+     * questions, on a slow model or a slow machine.
      */
-    const SETTLE_FRAMES = 1;
+    const SETTLE_FRAMES = 0;
+
+    /**
+     * How many frames to wait on an unanswered question before asking again.
+     *
+     * Not a delay -- nothing waits on this in the normal case. It is the escape
+     * from a question that never comes back, so a hover that failed once does
+     * not stay silent for the rest of the session.
+     */
+    const ABANDON_AFTER_FRAMES = 60;
 
     class HoverState {
         constructor(options) {
@@ -43,6 +56,8 @@
             this.slop = settings.slop === undefined ? MOVE_SLOP_PX : settings.slop;
             this.settleFrames = settings.settleFrames === undefined
                 ? SETTLE_FRAMES : settings.settleFrames;
+            this.abandonAfter = settings.abandonAfter === undefined
+                ? ABANDON_AFTER_FRAMES : settings.abandonAfter;
             this.reset();
         }
 
@@ -52,6 +67,8 @@
             this.at = null;
             this._pending = null;
             this._asked = 0;
+            this._outstanding = false;
+            this._waited = 0;
             this._stillFrames = 0;
         }
 
@@ -69,21 +86,40 @@
             }
             this._pending = { x, y };
             this._stillFrames = 0;
-            return { ask: false, reason: 'settling' };
+            return { ask: false, reason: 'pending' };
         }
 
         /**
-         * Time passed. Returns the point to ask about once the pointer settles.
+         * A frame passed. Returns the point to ask about, or nothing.
          *
          * Called from the render loop rather than a timer, so a hover cannot
          * outlive the viewer that owns it.
+         *
+         * One question at a time. Asking is not free and answering is not
+         * parallel -- the requests go to a single runner over a pipe and are
+         * answered one after another -- so firing per frame regardless would
+         * build a queue that gets answered long after the pointer has gone.
+         * Waiting for the answer instead paces this at exactly the rate the
+         * runner can keep up with, whatever that turns out to be.
+         *
+         * That is why settleFrames defaults to zero: the pacing comes from the
+         * answer rather than from a delay decided in advance.
          */
         due() {
+            if (this._outstanding) {
+                this._waited += 1;
+                if (this._waited < this.abandonAfter) {
+                    return null;
+                }
+                // Nothing came back. Give up rather than going quiet for good;
+                // if the answer ever arrives it is stale by number anyway.
+                this._outstanding = false;
+            }
             if (this._pending === null) {
                 return null;
             }
-            // Counted before it is raised, so a frame that had a move in it is
-            // not the still frame: the first call after moving always waits.
+            // Counted before it is raised, so a frame with a move in it is not
+            // a still one. At the default of zero this never waits.
             if (this._stillFrames < this.settleFrames) {
                 this._stillFrames += 1;
                 return null;
@@ -91,6 +127,8 @@
             const point = this._pending;
             this._pending = null;
             this._stillFrames = 0;
+            this._outstanding = true;
+            this._waited = 0;
             this._asked += 1;
             return { x: point.x, y: point.y, request: this._asked };
         }
@@ -102,6 +140,9 @@
          * pointer keeps moving while the runner is working.
          */
         answered(request, feature) {
+            if (request === this._asked) {
+                this._outstanding = false;
+            }
             if (request !== this._asked) {
                 return { kept: false, reason: 'stale' };
             }
@@ -157,7 +198,9 @@
         };
     }
 
-    const KigumiHover = { HoverState, hoverTarget, MOVE_SLOP_PX, SETTLE_FRAMES };
+    const KigumiHover = {
+        HoverState, hoverTarget, MOVE_SLOP_PX, SETTLE_FRAMES, ABANDON_AFTER_FRAMES,
+    };
 
     if (typeof module !== 'undefined' && module.exports) {
         module.exports = KigumiHover;

--- a/kigumi/webview/hover-state.js
+++ b/kigumi/webview/hover-state.js
@@ -99,14 +99,20 @@
             return { cleared: had };
         }
 
-        /** Whether two answers are about the same feature, so redrawing is pointless. */
+        /**
+         * Whether two answers are about the same feature, so redrawing is pointless.
+         *
+         * The feature's name as well as the path: two faces of one prism share
+         * a path and differ only by which face, so comparing paths alone would
+         * leave the first one drawn while the pointer sits on the second.
+         */
         static sameFeature(one, other) {
             if (!one || !other) {
                 return one === other;
             }
             return one.memberKey === other.memberKey
                 && (one.path || []).join('/') === (other.path || []).join('/')
-                && one.feature === other.feature;
+                && (one.featureLabel || null) === (other.featureLabel || null);
         }
     }
 

--- a/kigumi/webview/hover-state.js
+++ b/kigumi/webview/hover-state.js
@@ -110,7 +110,26 @@
         }
     }
 
-    const KigumiHover = { HoverState, MOVE_SLOP_PX, SETTLE_MS };
+    /**
+     * What to ask about, given the ray hits under the pointer.
+     *
+     * A hit is {memberKey, hit}, where the inner hit carries the world point --
+     * two nested things both reasonably called "hit", which is exactly how the
+     * wrong one gets used. Pinned here by a test rather than by memory.
+     */
+    function hoverTarget(hits) {
+        const found = (hits || [])[0];
+        if (!found || !found.hit || !found.hit.point) {
+            return null;
+        }
+        const point = found.hit.point;
+        return {
+            memberKey: found.memberKey,
+            point: [point.x, point.y, point.z],
+        };
+    }
+
+    const KigumiHover = { HoverState, hoverTarget, MOVE_SLOP_PX, SETTLE_MS };
 
     if (typeof module !== 'undefined' && module.exports) {
         module.exports = KigumiHover;

--- a/kigumi/webview/hover-state.js
+++ b/kigumi/webview/hover-state.js
@@ -20,21 +20,29 @@
     // affordable, but not free, so this also:
     //
     //   - ignores a move that has not travelled far enough to mean anything,
-    //   - waits for the pointer to settle before asking,
+    //   - waits for one still frame, so a sweep asks nothing on the way past,
     //   - keeps only the newest answer, since an older one is about a place the
     //     pointer has already left.
 
     /** Below this the pointer has not really moved, in canvas pixels. */
     const MOVE_SLOP_PX = 3;
 
-    /** How long the pointer settles before asking, in milliseconds. */
-    const SETTLE_MS = 40;
+    /**
+     * A pointer is settled once a frame has passed without it moving.
+     *
+     * Not a wait measured in milliseconds: any number long enough to be worth
+     * having is long enough to feel. One still frame is the shortest thing
+     * that means "stopped", and it costs nothing when the pointer is sweeping,
+     * since every frame of a sweep has a move in it.
+     */
+    const SETTLE_FRAMES = 1;
 
     class HoverState {
         constructor(options) {
             const settings = options || {};
             this.slop = settings.slop === undefined ? MOVE_SLOP_PX : settings.slop;
-            this.settle = settings.settle === undefined ? SETTLE_MS : settings.settle;
+            this.settleFrames = settings.settleFrames === undefined
+                ? SETTLE_FRAMES : settings.settleFrames;
             this.reset();
         }
 
@@ -44,6 +52,7 @@
             this.at = null;
             this._pending = null;
             this._asked = 0;
+            this._stillFrames = 0;
         }
 
         /**
@@ -51,14 +60,15 @@
          *
          * `now` is passed in rather than read, so a test can drive time.
          */
-        moved(x, y, now) {
+        moved(x, y) {
             const far = this.at === null
                 || Math.abs(x - this.at.x) + Math.abs(y - this.at.y) > this.slop;
             this.at = { x, y };
             if (!far) {
                 return { ask: false, reason: 'barely-moved' };
             }
-            this._pending = { x, y, since: now };
+            this._pending = { x, y };
+            this._stillFrames = 0;
             return { ask: false, reason: 'settling' };
         }
 
@@ -68,12 +78,19 @@
          * Called from the render loop rather than a timer, so a hover cannot
          * outlive the viewer that owns it.
          */
-        due(now) {
-            if (this._pending === null || now - this._pending.since < this.settle) {
+        due() {
+            if (this._pending === null) {
+                return null;
+            }
+            // Counted before it is raised, so a frame that had a move in it is
+            // not the still frame: the first call after moving always waits.
+            if (this._stillFrames < this.settleFrames) {
+                this._stillFrames += 1;
                 return null;
             }
             const point = this._pending;
             this._pending = null;
+            this._stillFrames = 0;
             this._asked += 1;
             return { x: point.x, y: point.y, request: this._asked };
         }
@@ -117,25 +134,30 @@
     }
 
     /**
-     * What to ask about, given the ray hits under the pointer.
+     * What to ask about, given what a click here would act on.
      *
-     * A hit is {memberKey, hit}, where the inner hit carries the world point --
-     * two nested things both reasonably called "hit", which is exactly how the
-     * wrong one gets used. Pinned here by a test rather than by memory.
+     * Takes the pick decision rather than the ray hits, because those are not
+     * the same member: a click drills into a SELECTED timber wherever it sits
+     * along the ray, not into whatever is nearest. Handed the hits instead,
+     * hover asked about the frontmost one and lit something a click would not
+     * have touched.
+     *
+     * The shape is {memberKey, hit}, and the inner hit carries the world point
+     * -- two nested things both reasonably called "hit", which is exactly how
+     * the wrong one gets used.
      */
-    function hoverTarget(hits) {
-        const found = (hits || [])[0];
-        if (!found || !found.hit || !found.hit.point) {
+    function hoverTarget(decision) {
+        if (!decision || !decision.hit || !decision.hit.point) {
             return null;
         }
-        const point = found.hit.point;
+        const point = decision.hit.point;
         return {
-            memberKey: found.memberKey,
+            memberKey: decision.memberKey,
             point: [point.x, point.y, point.z],
         };
     }
 
-    const KigumiHover = { HoverState, hoverTarget, MOVE_SLOP_PX, SETTLE_MS };
+    const KigumiHover = { HoverState, hoverTarget, MOVE_SLOP_PX, SETTLE_FRAMES };
 
     if (typeof module !== 'undefined' && module.exports) {
         module.exports = KigumiHover;

--- a/kigumi/webview/hover-state.js
+++ b/kigumi/webview/hover-state.js
@@ -1,0 +1,119 @@
+(function (globalScope) {
+    'use strict';
+    // What the pointer is over, and how often it is worth asking.
+    //
+    // Hover is a pick that does not commit: the same question a click asks,
+    // with none of the consequences. Kept apart from selection deliberately --
+    // moving the mouse must never change what is selected, and the two are
+    // drawn differently so "about to click" and "clicked" cannot be confused.
+    //
+    //
+    // WHY THIS IS NOT JUST A CLICK PER MOUSE MOVE
+    //
+    // Answering a click costs about 78ms on a timber of any size, nearly all of
+    // it walking every triangle to build a highlight mesh. Mouse moves arrive
+    // every 16ms. Asking per move would queue faster than it could answer and
+    // the highlight would trail the pointer by seconds.
+    //
+    // So hover asks a cheaper question -- resolve the feature, outline it from
+    // the CSG, never touch the mesh -- which measures about 4ms. That is
+    // affordable, but not free, so this also:
+    //
+    //   - ignores a move that has not travelled far enough to mean anything,
+    //   - waits for the pointer to settle before asking,
+    //   - keeps only the newest answer, since an older one is about a place the
+    //     pointer has already left.
+
+    /** Below this the pointer has not really moved, in canvas pixels. */
+    const MOVE_SLOP_PX = 3;
+
+    /** How long the pointer settles before asking, in milliseconds. */
+    const SETTLE_MS = 40;
+
+    class HoverState {
+        constructor(options) {
+            const settings = options || {};
+            this.slop = settings.slop === undefined ? MOVE_SLOP_PX : settings.slop;
+            this.settle = settings.settle === undefined ? SETTLE_MS : settings.settle;
+            this.reset();
+        }
+
+        reset() {
+            /** What is under the pointer, as the runner answered. */
+            this.feature = null;
+            this.at = null;
+            this._pending = null;
+            this._asked = 0;
+        }
+
+        /**
+         * The pointer moved. Returns whether it is worth asking about.
+         *
+         * `now` is passed in rather than read, so a test can drive time.
+         */
+        moved(x, y, now) {
+            const far = this.at === null
+                || Math.abs(x - this.at.x) + Math.abs(y - this.at.y) > this.slop;
+            this.at = { x, y };
+            if (!far) {
+                return { ask: false, reason: 'barely-moved' };
+            }
+            this._pending = { x, y, since: now };
+            return { ask: false, reason: 'settling' };
+        }
+
+        /**
+         * Time passed. Returns the point to ask about once the pointer settles.
+         *
+         * Called from the render loop rather than a timer, so a hover cannot
+         * outlive the viewer that owns it.
+         */
+        due(now) {
+            if (this._pending === null || now - this._pending.since < this.settle) {
+                return null;
+            }
+            const point = this._pending;
+            this._pending = null;
+            this._asked += 1;
+            return { x: point.x, y: point.y, request: this._asked };
+        }
+
+        /**
+         * An answer came back. Ignored if a newer question has been asked since.
+         *
+         * Out-of-order answers are the normal case, not an edge one: the
+         * pointer keeps moving while the runner is working.
+         */
+        answered(request, feature) {
+            if (request !== this._asked) {
+                return { kept: false, reason: 'stale' };
+            }
+            this.feature = feature || null;
+            return { kept: true, feature: this.feature };
+        }
+
+        /** The pointer left, or the mode changed: hold nothing. */
+        clear() {
+            const had = this.feature !== null;
+            this.reset();
+            return { cleared: had };
+        }
+
+        /** Whether two answers are about the same feature, so redrawing is pointless. */
+        static sameFeature(one, other) {
+            if (!one || !other) {
+                return one === other;
+            }
+            return one.memberKey === other.memberKey
+                && (one.path || []).join('/') === (other.path || []).join('/')
+                && one.feature === other.feature;
+        }
+    }
+
+    const KigumiHover = { HoverState, MOVE_SLOP_PX, SETTLE_MS };
+
+    if (typeof module !== 'undefined' && module.exports) {
+        module.exports = KigumiHover;
+    }
+    globalScope.KigumiHover = KigumiHover;
+})(typeof window !== 'undefined' ? window : globalThis);

--- a/kigumi/webview/viewer-app.js
+++ b/kigumi/webview/viewer-app.js
@@ -3028,7 +3028,7 @@ class KigumiViewerApp extends LitElement {
             this._hover = new window.KigumiHover.HoverState();
         }
         this._hoverClient = { x: event.clientX, y: event.clientY };
-        this._hover.moved(event.clientX, event.clientY, performance.now());
+        this._hover.moved(event.clientX, event.clientY);
     }
 
     /**
@@ -3042,29 +3042,27 @@ class KigumiViewerApp extends LitElement {
         if (!this._hover || typeof vscode === 'undefined') {
             return;
         }
-        const due = this._hover.due(performance.now());
+        const due = this._hover.due();
         if (!due || !this._hoverClient) {
             return;
         }
-        const hits = this._findMembersAlongRay(this._hoverClient.x, this._hoverClient.y);
-        const target = window.KigumiHover.hoverTarget(hits);
-        if (!target) {
-            // Off the model. Nothing to ask, and nothing should stay lit.
-            this._hover.clear();
-            this.clearHoverOutline();
-            return;
-        }
-
-        // The same decision a click makes, so hover shows what a click would
-        // do rather than something else. Clicking an unselected timber selects
-        // the whole timber; clicking one already selected drills into it. Only
-        // the second has a feature to ask the runner about.
+        // The same decision a click makes, so hover shows what a click would do
+        // rather than something else. Clicking an unselected timber selects the
+        // whole timber; clicking one already selected drills into it. Only the
+        // second has a feature to ask the runner about.
+        //
+        // The decision also says WHICH member, which is not the nearest one: a
+        // click drills into the selected timber wherever it sits along the ray.
         const decision = choosePickAction({
-            hits,
+            hits: this._findMembersAlongRay(this._hoverClient.x, this._hoverClient.y),
             selectedTimbers: this.selectionManager.selectedTimbers,
             shiftKey: false,
         });
-        if (decision.action !== 'csg') {
+        const target = window.KigumiHover.hoverTarget(decision);
+        if (decision.action !== 'csg' || !target) {
+            // Either nothing under the pointer, or a click here would take the
+            // whole timber rather than anything inside it.
+            this._hover.clear();
             this.clearHoverOutline();
             return;
         }

--- a/kigumi/webview/viewer-app.js
+++ b/kigumi/webview/viewer-app.js
@@ -278,8 +278,8 @@ const CSG_HIGHLIGHT_COLORS = Object.freeze({
 // What the pointer is over, as opposed to what is selected. A different hue as
 // well as a different shape -- an outline rather than a fill -- so the two
 // never read as the same state.
-const HOVER_OUTLINE_COLOR = 0xffa726;
-const HOVER_OUTLINE_WIDTH_PX = 3;
+const HOVER_COLOR = 0xffa726;
+const HOVER_OPACITY = 0.55;
 
 // A selected edge is drawn as a line rather than shaded like a face, so it
 // needs a width of its own -- several times the timbers' own edge lines, or the
@@ -3046,21 +3046,38 @@ class KigumiViewerApp extends LitElement {
         if (!due || !this._hoverClient) {
             return;
         }
-        const target = window.KigumiHover.hoverTarget(
-            this._findMembersAlongRay(this._hoverClient.x, this._hoverClient.y),
-        );
+        const hits = this._findMembersAlongRay(this._hoverClient.x, this._hoverClient.y);
+        const target = window.KigumiHover.hoverTarget(hits);
         if (!target) {
             // Off the model. Nothing to ask, and nothing should stay lit.
-            if (this._hover.feature) {
-                this._hover.clear();
-                this.clearHoverOutline();
-            }
+            this._hover.clear();
+            this.clearHoverOutline();
             return;
         }
+
+        // The same decision a click makes, so hover shows what a click would
+        // do rather than something else. Clicking an unselected timber selects
+        // the whole timber; clicking one already selected drills into it. Only
+        // the second has a feature to ask the runner about.
+        const decision = choosePickAction({
+            hits,
+            selectedTimbers: this.selectionManager.selectedTimbers,
+            shiftKey: false,
+        });
+        if (decision.action !== 'csg') {
+            this.clearHoverOutline();
+            return;
+        }
+
+        // From wherever the selection already is, exactly as the click does.
+        const focus = this.selectionManager.csgFocus;
+        const currentPath = (focus && focus.timberKey === target.memberKey) ? focus.path : [];
         vscode.postMessage({
             type: 'hoverFeatureAtPoint',
             memberKey: target.memberKey,
             point: target.point,
+            currentPath,
+            ctrlClick: false,
             request: due.request,
         });
     }
@@ -3078,56 +3095,60 @@ class KigumiViewerApp extends LitElement {
             return;
         }
         this._hoverDrawn = message;
-        this.drawHoverOutline(message.outline);
+        this.drawHoverHighlight(message);
     }
 
     /**
-     * Outline what is under the pointer.
+     * Draw what a click would have highlighted, in the hover colour.
      *
-     * A line, never a filled highlight: this says what a click would take, and
-     * it has to be tellable apart from what a click already took. The shape is
-     * the feature's own outline from the CSG -- see _feature_outline, which
-     * also says where it is only approximate.
+     * The same mesh and the same line the selection uses, from the same runner
+     * answer -- only the colour and the render order differ. Drawing it any
+     * other way is how hover ends up showing something a click would not do:
+     * an outline taken from the CSG was convex, so a timber face with mortises
+     * through it lit as a whole rectangle over the openings.
      */
-    drawHoverOutline(outline) {
+    drawHoverHighlight(message) {
         this.clearHoverOutline();
-        if (!Array.isArray(outline) || outline.length < 2) {
-            return;
+        const mesh = message.highlightMesh;
+        const edge = message.highlightEdge;
+
+        if (edge && Array.isArray(edge.start) && Array.isArray(edge.end)) {
+            this._buildHoverEdgeLine(edge.start, edge.end);
         }
-        const positions = [];
-        for (let index = 0; index < outline.length; index += 1) {
-            // Closed for a face, open for an edge's two ends.
-            const next = outline.length > 2 ? outline[(index + 1) % outline.length] : outline[index + 1];
-            if (!next) {
-                break;
+        if (mesh && Array.isArray(mesh.vertices) && mesh.vertices.length > 0) {
+            this._buildHighlightMesh(
+                mesh.vertices, mesh.indices, HOVER_COLOR, HOVER_OPACITY, '_hoverHighlightMesh',
+            );
+            // Under the selection's own highlight, which sits at 999: what is
+            // selected outranks what is merely under the pointer.
+            if (this._hoverHighlightMesh) {
+                this._hoverHighlightMesh.renderOrder = 900;
             }
-            positions.push(...outline[index], ...next);
         }
-        if (positions.length === 0) {
-            return;
-        }
+    }
+
+    _buildHoverEdgeLine(start, end) {
         const geometry = new THREE.LineSegmentsGeometry();
-        geometry.setPositions(positions);
+        geometry.setPositions([...start, ...end]);
         const material = new THREE.LineMaterial({
-            color: HOVER_OUTLINE_COLOR,
-            linewidth: HOVER_OUTLINE_WIDTH_PX,
+            color: HOVER_COLOR,
+            linewidth: CSG_HIGHLIGHT_EDGE_WIDTH_PX,
             resolution: this._getRendererResolution(),
             depthTest: false,
             transparent: true,
-            opacity: 0.9,
+            opacity: HOVER_OPACITY,
         });
         const line = new THREE.LineSegments2(geometry, material);
         line.computeLineDistances();
-        // Under the selection highlight, which is at 1000: what is selected
-        // matters more than what is merely under the pointer.
-        line.renderOrder = 900;
+        line.renderOrder = 901;
         this.scene.add(line);
-        this._hoverOutline = line;
+        this._hoverHighlightEdge = line;
     }
 
     clearHoverOutline() {
         this._hoverDrawn = null;
-        this._disposeHighlightMesh('_hoverOutline');
+        this._disposeHighlightMesh('_hoverHighlightMesh');
+        this._disposeHighlightMesh('_hoverHighlightEdge');
     }
 
     /** Leaving the canvas, or changing mode: nothing should stay lit. */

--- a/kigumi/webview/viewer-app.js
+++ b/kigumi/webview/viewer-app.js
@@ -1856,7 +1856,18 @@ class KigumiViewerApp extends LitElement {
             this.updateCylinderSilhouettes();
             // Asked from here rather than a timer: a hover cannot outlive the
             // viewer, and nothing is asked while the tab is not drawing.
-            this.pumpHover();
+            //
+            // Guarded because this runs inside the frame: a throw here would
+            // stop renderViewports below it and freeze the view, which is a
+            // spectacular way for a hover to fail.
+            try {
+                this.pumpHover();
+            } catch (error) {
+                if (!this._hoverBroken) {
+                    this._hoverBroken = true;
+                    this.emitViewerLog('hover-error', { message: String(error && error.message || error) });
+                }
+            }
             this.renderViewports();
         };
         animate();
@@ -3035,9 +3046,10 @@ class KigumiViewerApp extends LitElement {
         if (!due || !this._hoverClient) {
             return;
         }
-        const hits = this._findMembersAlongRay(this._hoverClient.x, this._hoverClient.y);
-        const hit = hits[0] || null;
-        if (!hit) {
+        const target = window.KigumiHover.hoverTarget(
+            this._findMembersAlongRay(this._hoverClient.x, this._hoverClient.y),
+        );
+        if (!target) {
             // Off the model. Nothing to ask, and nothing should stay lit.
             if (this._hover.feature) {
                 this._hover.clear();
@@ -3047,8 +3059,8 @@ class KigumiViewerApp extends LitElement {
         }
         vscode.postMessage({
             type: 'hoverFeatureAtPoint',
-            memberKey: hit.memberKey,
-            point: [hit.point.x, hit.point.y, hit.point.z],
+            memberKey: target.memberKey,
+            point: target.point,
             request: due.request,
         });
     }

--- a/kigumi/webview/viewer-app.js
+++ b/kigumi/webview/viewer-app.js
@@ -275,6 +275,12 @@ const CSG_HIGHLIGHT_COLORS = Object.freeze({
     feature: 0x0288d1,
 });
 
+// What the pointer is over, as opposed to what is selected. A different hue as
+// well as a different shape -- an outline rather than a fill -- so the two
+// never read as the same state.
+const HOVER_OUTLINE_COLOR = 0xffa726;
+const HOVER_OUTLINE_WIDTH_PX = 3;
+
 // A selected edge is drawn as a line rather than shaded like a face, so it
 // needs a width of its own -- several times the timbers' own edge lines, or the
 // selection does not read as thicker than the geometry it sits on.
@@ -1678,6 +1684,13 @@ class KigumiViewerApp extends LitElement {
             window.scrollTo({ top: 0, behavior: 'smooth' });
         });
 
+        canvas.addEventListener('pointermove', (event) => {
+            this.handleCanvasHover(event);
+        });
+        canvas.addEventListener('pointerleave', () => {
+            this.clearHover();
+        });
+
         canvas.addEventListener('mousedown', (event) => {
             const action = actionForButton(event.button, this.leftClickDragRotatesCamera);
             if (!action) {
@@ -1841,6 +1854,9 @@ class KigumiViewerApp extends LitElement {
             this.stepCameraAnimation();
             this.renderCameraControls();
             this.updateCylinderSilhouettes();
+            // Asked from here rather than a timer: a hover cannot outlive the
+            // viewer, and nothing is asked while the tab is not drawing.
+            this.pumpHover();
             this.renderViewports();
         };
         animate();
@@ -2526,6 +2542,11 @@ class KigumiViewerApp extends LitElement {
             return;
         }
 
+        if (message.type === 'hoverFeatureResult') {
+            this.handleHoverResult(message);
+            return;
+        }
+
         if (message.type === 'csgSelectionResult') {
             this.handleCSGSelectionResult(message);
             return;
@@ -2984,6 +3005,126 @@ class KigumiViewerApp extends LitElement {
         this.selectionManager.clearCsgFocus();
         this.lastPickDetail = null;
         this.removeCSGHighlight();
+    }
+
+    // -------------------------------------------------------------------------
+    // Hover: what the pointer is over, without selecting it
+    // -------------------------------------------------------------------------
+
+    /** The pointer moved over the canvas. Cheap: no request goes out here. */
+    handleCanvasHover(event) {
+        if (!this._hover) {
+            this._hover = new window.KigumiHover.HoverState();
+        }
+        this._hoverClient = { x: event.clientX, y: event.clientY };
+        this._hover.moved(event.clientX, event.clientY, performance.now());
+    }
+
+    /**
+     * Ask about the pointer, once it has settled.
+     *
+     * Driven from the render loop rather than a timer, so a hover cannot
+     * outlive the viewer that owns it, and so nothing is asked while the tab
+     * is not drawing.
+     */
+    pumpHover() {
+        if (!this._hover || typeof vscode === 'undefined') {
+            return;
+        }
+        const due = this._hover.due(performance.now());
+        if (!due || !this._hoverClient) {
+            return;
+        }
+        const hits = this._findMembersAlongRay(this._hoverClient.x, this._hoverClient.y);
+        const hit = hits[0] || null;
+        if (!hit) {
+            // Off the model. Nothing to ask, and nothing should stay lit.
+            if (this._hover.feature) {
+                this._hover.clear();
+                this.clearHoverOutline();
+            }
+            return;
+        }
+        vscode.postMessage({
+            type: 'hoverFeatureAtPoint',
+            memberKey: hit.memberKey,
+            point: [hit.point.x, hit.point.y, hit.point.z],
+            request: due.request,
+        });
+    }
+
+    /** An answer came back. Draws only when it is about somewhere new. */
+    handleHoverResult(message) {
+        if (!this._hover) {
+            return;
+        }
+        const kept = this._hover.answered(message.request, message);
+        if (!kept.kept) {
+            return;
+        }
+        if (window.KigumiHover.HoverState.sameFeature(this._hoverDrawn, message)) {
+            return;
+        }
+        this._hoverDrawn = message;
+        this.drawHoverOutline(message.outline);
+    }
+
+    /**
+     * Outline what is under the pointer.
+     *
+     * A line, never a filled highlight: this says what a click would take, and
+     * it has to be tellable apart from what a click already took. The shape is
+     * the feature's own outline from the CSG -- see _feature_outline, which
+     * also says where it is only approximate.
+     */
+    drawHoverOutline(outline) {
+        this.clearHoverOutline();
+        if (!Array.isArray(outline) || outline.length < 2) {
+            return;
+        }
+        const positions = [];
+        for (let index = 0; index < outline.length; index += 1) {
+            // Closed for a face, open for an edge's two ends.
+            const next = outline.length > 2 ? outline[(index + 1) % outline.length] : outline[index + 1];
+            if (!next) {
+                break;
+            }
+            positions.push(...outline[index], ...next);
+        }
+        if (positions.length === 0) {
+            return;
+        }
+        const geometry = new THREE.LineSegmentsGeometry();
+        geometry.setPositions(positions);
+        const material = new THREE.LineMaterial({
+            color: HOVER_OUTLINE_COLOR,
+            linewidth: HOVER_OUTLINE_WIDTH_PX,
+            resolution: this._getRendererResolution(),
+            depthTest: false,
+            transparent: true,
+            opacity: 0.9,
+        });
+        const line = new THREE.LineSegments2(geometry, material);
+        line.computeLineDistances();
+        // Under the selection highlight, which is at 1000: what is selected
+        // matters more than what is merely under the pointer.
+        line.renderOrder = 900;
+        this.scene.add(line);
+        this._hoverOutline = line;
+    }
+
+    clearHoverOutline() {
+        this._hoverDrawn = null;
+        this._disposeHighlightMesh('_hoverOutline');
+    }
+
+    /** Leaving the canvas, or changing mode: nothing should stay lit. */
+    clearHover() {
+        if (this._hover) {
+            this._hover.clear();
+        }
+        this._hoverClient = null;
+        this.clearHoverOutline();
     }
 
     handleCanvasClick(event) {

--- a/kigumi/webview/viewer.html
+++ b/kigumi/webview/viewer.html
@@ -37,6 +37,8 @@
     <script nonce="__NONCE__" src="__SCENE_MANAGER_JS_URI__"></script>
     <script nonce="__NONCE__" src="__INPUT_CONTROLLER_JS_URI__"></script>
     <script nonce="__NONCE__" src="__MEASUREMENTS_JS_URI__"></script>
+    <script nonce="__NONCE__" src="__HOVER_STATE_JS_URI__"></script>
+    <script nonce="__NONCE__" src="__MEASURE_MODE_JS_URI__"></script>
     <script nonce="__NONCE__" src="__DRAWING_PANEL_JS_URI__"></script>
     <script nonce="__NONCE__" src="__GEOMETRY_MODE_JS_URI__"></script>
     <script nonce="__NONCE__" type="module" src="__APP_JS_URI__"></script>

--- a/tests/test_kigumi_csg_navigation.py
+++ b/tests/test_kigumi_csg_navigation.py
@@ -1389,21 +1389,30 @@ class TestPickYieldsAMeasurementReference:
 
 
 class TestHoveringOverAFeature:
-    """What is under the pointer, answered cheaply enough to ask while it moves.
+    """What the pointer is over: the answer a click would give, without clicking.
 
-    A click walks every triangle of the timber to build its highlight, which is
-    far too slow to run per mouse move. Hover resolves the same feature and
-    outlines it from the CSG instead.
+    Deliberately the same code as a click. An outline drawn from the CSG was
+    cheaper and wrong in a way that showed -- a face with mortises through it
+    outlined as a whole rectangle over the openings -- so hover asks the same
+    question and the viewer draws the answer differently.
     """
 
     def _slot(self, frame, member):
+        from kumiki.triangles import triangulate_cutcsg
+
         cut_timber = _cut_timber_by_name(frame, member)
+        timber = cut_timber.timber
         local = cut_timber.render_timber_with_cuts_csg_local()
+        vertices = []
+        for triangle in triangulate_cutcsg(local).mesh.triangles:
+            for vertex in triangle:
+                world = timber.transform.local_to_global(
+                    runner._to_v3([float(vertex[i]) for i in range(3)]))
+                vertices.extend([float(world[i, 0]) for i in range(3)])
+        mesh = {"vertices": vertices, "indices": list(range(len(vertices) // 3))}
 
         class Slot:
-            mesh_cache = {member: {"local_csg": local,
-                                   "cut_timber": cut_timber,
-                                   "mesh": None}}
+            mesh_cache = {member: {"local_csg": local, "cut_timber": cut_timber, "mesh": mesh}}
 
         class State:
             _active = Slot()
@@ -1423,16 +1432,17 @@ class TestHoveringOverAFeature:
                         return [float(world[i, 0]) for i in range(3)]
         raise AssertionError("no such feature on the surface")
 
-    def _hover(self, frame, member, predicate):
+    def _hover(self, frame, member, predicate, **extra):
         state, slot, local, cut_timber = self._slot(frame, member)
         point = self._a_point_on(local, cut_timber, predicate)
-        return runner._handle_hover_feature_at_point(
-            state, {"memberKey": member, "point": point}, slot)
+        payload = {"memberKey": member, "point": point, "currentPath": [], "ctrlClick": False}
+        payload.update(extra)
+        return runner._handle_hover_feature_at_point(state, payload, slot)
 
-    def _hover_until(self, frame, member, wanted):
-        """Hover over surface points until one resolves to what is wanted.
+    def _hover_until(self, frame, member, wanted, **extra):
+        """Hover over surface points until one answers what is wanted.
 
-        By the result rather than by the feature under the point: a point on a
+        By the result rather than the feature under the point: a point on a
         face is often on one of its edges too, and an edge is the better answer
         there -- which is what a click does as well.
         """
@@ -1444,23 +1454,46 @@ class TestHoveringOverAFeature:
             for vertex in triangle:
                 world = timber.transform.local_to_global(
                     runner._to_v3([float(vertex[i]) for i in range(3)]))
-                result = runner._handle_hover_feature_at_point(
-                    state, {"memberKey": member,
-                            "point": [float(world[i, 0]) for i in range(3)]}, slot)
+                payload = {"memberKey": member,
+                           "point": [float(world[i, 0]) for i in range(3)],
+                           "currentPath": [], "ctrlClick": False}
+                payload.update(extra)
+                result = runner._handle_hover_feature_at_point(state, payload, slot)
                 if wanted(result):
                     return result
-        raise AssertionError("nothing on the surface resolved to what was wanted")
+        raise AssertionError("nothing on the surface answered what was wanted")
 
-    def test_a_face_comes_back_outlined(self, mortise_and_tenon_frame):
+    def test_a_face_answers_with_the_triangles_a_click_would_light(self, mortise_and_tenon_frame):
         result = self._hover_until(
             mortise_and_tenon_frame, "receiving_timber",
-            lambda r: r["featureType"] == "FACE" and r["outline"])
+            lambda r: r["featureType"] == "FACE" and r["highlightMesh"]["vertices"])
 
-        # A convex region, so at least a triangle's worth of corners.
-        assert len(result["outline"]) >= 3
-        assert all(len(corner) == 3 for corner in result["outline"])
+        # Real triangles off the rendered mesh -- so a face with something cut
+        # through it comes back with the hole missing, which is the whole point
+        # of not drawing this from the CSG.
+        assert len(result["highlightMesh"]["vertices"]) % 9 == 0
+        assert result["featureLabel"] is not None
 
-    def test_an_edge_comes_back_as_its_two_ends(self, mortise_and_tenon_frame):
+    def test_it_is_the_same_answer_a_click_gives(self, mortise_and_tenon_frame):
+        # Not a likeness of it. The only difference is what the viewer does
+        # with it: another colour, and under the selection.
+        from kumiki.cutcsg import CSGFeatureType
+
+        state, slot, local, cut_timber = self._slot(mortise_and_tenon_frame, "receiving_timber")
+        point = self._a_point_on(local, cut_timber,
+                                 lambda f: f.feature_type() == CSGFeatureType.FACE)
+        payload = {"memberKey": "receiving_timber", "point": point,
+                   "currentPath": [], "ctrlClick": False}
+
+        hovered = runner._handle_hover_feature_at_point(state, dict(payload), slot)
+        clicked = runner._handle_find_csg_at_point(state, dict(payload), slot)
+
+        assert hovered["path"] == clicked["path"]
+        assert hovered["featureLabel"] == clicked["featureLabel"]
+        assert hovered["highlightMesh"] == clicked["highlightMesh"]
+        assert hovered["highlightEdge"] == clicked["highlightEdge"]
+
+    def test_an_edge_comes_back_as_a_line_to_draw(self, mortise_and_tenon_frame):
         from kumiki.cutcsg import CSGFeatureType
 
         result = self._hover(
@@ -1468,7 +1501,7 @@ class TestHoveringOverAFeature:
             lambda f: f.feature_type() == CSGFeatureType.EDGE)
 
         assert result["featureType"] == "EDGE"
-        assert len(result["outline"]) == 2
+        assert result["highlightEdge"]["start"] and result["highlightEdge"]["end"]
 
     def test_it_says_what_a_measurement_would_hold(self, mortise_and_tenon_frame):
         # So the viewer can say whether this and whatever is already held could
@@ -1482,13 +1515,20 @@ class TestHoveringOverAFeature:
         assert result["reference"] is not None
         assert runner.resolve_anchor(mortise_and_tenon_frame, result["reference"]) is not None
 
-    def test_it_does_not_touch_the_mesh(self, mortise_and_tenon_frame):
-        # The whole reason it can run while the pointer moves. The cache entry
-        # has no mesh at all here, and hovering still answers.
-        result = self._hover_until(
-            mortise_and_tenon_frame, "receiving_timber", lambda r: r["feature"] is not None)
+    def test_it_drills_from_where_the_selection_already_is(self, mortise_and_tenon_frame):
+        # Hover has to follow the same rules as clicking, or it shows something
+        # a click would not do. Held path and ctrl included: whatever they mean
+        # to a click, they mean the same here.
+        state, slot, local, cut_timber = self._slot(mortise_and_tenon_frame, "receiving_timber")
+        point = self._a_point_on(local, cut_timber, lambda f: True)
+        payload = {"memberKey": "receiving_timber", "point": point,
+                   "currentPath": ["mortise_and_tenon"], "ctrlClick": True}
 
-        assert result["feature"] is not None
+        hovered = runner._handle_hover_feature_at_point(state, dict(payload), slot)
+        clicked = runner._handle_find_csg_at_point(state, dict(payload), slot)
+
+        assert hovered["path"] == clicked["path"]
+        assert hovered["nodeLabel"] == clicked["nodeLabel"]
 
     def test_an_unknown_member_is_refused(self):
         class Slot:
@@ -1509,28 +1549,21 @@ class TestHoveringOverAFeature:
 
         class Runner:
             _active = slot
-            slots = {"main": slot}
-            active_slot = "main"
 
-        request = {
-            "id": "hover-1",
-            "command": "hover_feature_at_point",
-            "payload": {"memberKey": "receiving_timber", "point": point},
-        }
-
-        # _resolve_slot needs a slot to find; give it the one we built.
-        import types
-        runner_state = Runner()
         original = runner._resolve_slot
         runner._resolve_slot = lambda state, payload: slot
         try:
-            _state, response, _stop = runner.handle_request(runner_state, request)
+            _state, response, _stop = runner.handle_request(Runner(), {
+                "id": "hover-1",
+                "command": "hover_feature_at_point",
+                "payload": {"memberKey": "receiving_timber", "point": point},
+            })
         finally:
             runner._resolve_slot = original
 
         assert response.get("ok") is not False, response
         result = response.get("result") or response.get("payload") or {}
-        assert "outline" in result or "feature" in result, response
+        assert result.get("highlightMesh") is not None, response
 
 
 class TestTheBroadphase:

--- a/tests/test_kigumi_csg_navigation.py
+++ b/tests/test_kigumi_csg_navigation.py
@@ -1386,3 +1386,117 @@ class TestPickYieldsAMeasurementReference:
     def test_a_pick_still_drilling_down_references_nothing(self, mortise_and_tenon_frame):
         # No feature reached yet, so there is nothing to measure to.
         assert runner._pick_reference(None, "t#0", ["cut"], None, None, None) is None
+
+
+class TestHoveringOverAFeature:
+    """What is under the pointer, answered cheaply enough to ask while it moves.
+
+    A click walks every triangle of the timber to build its highlight, which is
+    far too slow to run per mouse move. Hover resolves the same feature and
+    outlines it from the CSG instead.
+    """
+
+    def _slot(self, frame, member):
+        cut_timber = _cut_timber_by_name(frame, member)
+        local = cut_timber.render_timber_with_cuts_csg_local()
+
+        class Slot:
+            mesh_cache = {member: {"local_csg": local,
+                                   "cut_timber": cut_timber,
+                                   "mesh": None}}
+
+        class State:
+            _active = Slot()
+
+        return State(), Slot(), local, cut_timber
+
+    def _a_point_on(self, local, cut_timber, predicate):
+        from kumiki.triangles import triangulate_cutcsg
+
+        timber = cut_timber.timber
+        for triangle in triangulate_cutcsg(local).mesh.triangles:
+            for vertex in triangle:
+                local_pt = [float(vertex[i]) for i in range(3)]
+                for hit in local.get_all_features(runner._to_v3(local_pt)):
+                    if predicate(hit.feature):
+                        world = timber.transform.local_to_global(runner._to_v3(local_pt))
+                        return [float(world[i, 0]) for i in range(3)]
+        raise AssertionError("no such feature on the surface")
+
+    def _hover(self, frame, member, predicate):
+        state, slot, local, cut_timber = self._slot(frame, member)
+        point = self._a_point_on(local, cut_timber, predicate)
+        return runner._handle_hover_feature_at_point(
+            state, {"memberKey": member, "point": point}, slot)
+
+    def _hover_until(self, frame, member, wanted):
+        """Hover over surface points until one resolves to what is wanted.
+
+        By the result rather than by the feature under the point: a point on a
+        face is often on one of its edges too, and an edge is the better answer
+        there -- which is what a click does as well.
+        """
+        from kumiki.triangles import triangulate_cutcsg
+
+        state, slot, local, cut_timber = self._slot(frame, member)
+        timber = cut_timber.timber
+        for triangle in triangulate_cutcsg(local).mesh.triangles:
+            for vertex in triangle:
+                world = timber.transform.local_to_global(
+                    runner._to_v3([float(vertex[i]) for i in range(3)]))
+                result = runner._handle_hover_feature_at_point(
+                    state, {"memberKey": member,
+                            "point": [float(world[i, 0]) for i in range(3)]}, slot)
+                if wanted(result):
+                    return result
+        raise AssertionError("nothing on the surface resolved to what was wanted")
+
+    def test_a_face_comes_back_outlined(self, mortise_and_tenon_frame):
+        result = self._hover_until(
+            mortise_and_tenon_frame, "receiving_timber",
+            lambda r: r["featureType"] == "FACE" and r["outline"])
+
+        # A convex region, so at least a triangle's worth of corners.
+        assert len(result["outline"]) >= 3
+        assert all(len(corner) == 3 for corner in result["outline"])
+
+    def test_an_edge_comes_back_as_its_two_ends(self, mortise_and_tenon_frame):
+        from kumiki.cutcsg import CSGFeatureType
+
+        result = self._hover(
+            mortise_and_tenon_frame, "receiving_timber",
+            lambda f: f.feature_type() == CSGFeatureType.EDGE)
+
+        assert result["featureType"] == "EDGE"
+        assert len(result["outline"]) == 2
+
+    def test_it_says_what_a_measurement_would_hold(self, mortise_and_tenon_frame):
+        # So the viewer can say whether this and whatever is already held could
+        # be measured -- before the click, which is the point of hovering.
+        from kumiki.cutcsg import CSGFeatureType
+
+        result = self._hover(
+            mortise_and_tenon_frame, "receiving_timber",
+            lambda f: f.feature_type() == CSGFeatureType.EDGE)
+
+        assert result["reference"] is not None
+        assert runner.resolve_anchor(mortise_and_tenon_frame, result["reference"]) is not None
+
+    def test_it_does_not_touch_the_mesh(self, mortise_and_tenon_frame):
+        # The whole reason it can run while the pointer moves. The cache entry
+        # has no mesh at all here, and hovering still answers.
+        result = self._hover_until(
+            mortise_and_tenon_frame, "receiving_timber", lambda r: r["feature"] is not None)
+
+        assert result["feature"] is not None
+
+    def test_an_unknown_member_is_refused(self):
+        class Slot:
+            mesh_cache = {}
+
+        class State:
+            _active = Slot()
+
+        with pytest.raises(ValueError, match="Unknown memberKey"):
+            runner._handle_hover_feature_at_point(
+                State(), {"memberKey": "nope", "point": [0, 0, 0]}, Slot())

--- a/tests/test_kigumi_csg_navigation.py
+++ b/tests/test_kigumi_csg_navigation.py
@@ -1500,3 +1500,34 @@ class TestHoveringOverAFeature:
         with pytest.raises(ValueError, match="Unknown memberKey"):
             runner._handle_hover_feature_at_point(
                 State(), {"memberKey": "nope", "point": [0, 0, 0]}, Slot())
+
+    def test_the_command_answers_through_the_runner_protocol(self, mortise_and_tenon_frame):
+        # The dispatch, not just the handler: a command the protocol does not
+        # know about is a viewer that silently never hovers.
+        state, slot, local, cut_timber = self._slot(mortise_and_tenon_frame, "receiving_timber")
+        point = self._a_point_on(local, cut_timber, lambda f: True)
+
+        class Runner:
+            _active = slot
+            slots = {"main": slot}
+            active_slot = "main"
+
+        request = {
+            "id": "hover-1",
+            "command": "hover_feature_at_point",
+            "payload": {"memberKey": "receiving_timber", "point": point},
+        }
+
+        # _resolve_slot needs a slot to find; give it the one we built.
+        import types
+        runner_state = Runner()
+        original = runner._resolve_slot
+        runner._resolve_slot = lambda state, payload: slot
+        try:
+            _state, response, _stop = runner.handle_request(runner_state, request)
+        finally:
+            runner._resolve_slot = original
+
+        assert response.get("ok") is not False, response
+        result = response.get("result") or response.get("payload") or {}
+        assert "outline" in result or "feature" in result, response

--- a/tests/test_kigumi_csg_navigation.py
+++ b/tests/test_kigumi_csg_navigation.py
@@ -1531,3 +1531,75 @@ class TestHoveringOverAFeature:
         assert response.get("ok") is not False, response
         result = response.get("result") or response.get("payload") or {}
         assert "outline" in result or "feature" in result, response
+
+
+class TestTheBroadphase:
+    """Rejecting triangles by a box before asking the CSG about them."""
+
+    def test_a_box_rejects_what_is_outside_it(self, mortise_and_tenon_frame):
+        cut_timber = _cut_timber_by_name(mortise_and_tenon_frame, "receiving_timber")
+        local = cut_timber.render_timber_with_cuts_csg_local()
+        node = runner._find_csg_by_labels(
+            runner._roots_for_path(cut_timber, ("mortise_hole",))[0][0], ("mortise_hole",))
+
+        inside = runner._aabb_filter(node, 5e-4)
+
+        assert inside is not None
+        box = node.get_aabb()
+        middle = [(float(box.min_x) + float(box.max_x)) / 2,
+                  (float(box.min_y) + float(box.max_y)) / 2,
+                  (float(box.min_z) + float(box.max_z)) / 2]
+        assert inside(middle)
+        assert not inside([float(box.max_x) + 1.0, middle[1], middle[2]])
+
+    def test_an_unbounded_solid_cannot_be_filtered(self):
+        # A half space has no box worth having, so the walk goes ahead
+        # unfiltered rather than rejecting everything.
+        from kumiki.cutcsg import HalfSpace
+        from kumiki.rule import create_v3, scalar
+
+        unbounded = HalfSpace(normal=create_v3(scalar(0), scalar(0), scalar(1)),
+                              offset=scalar(0))
+
+        assert runner._aabb_filter(unbounded, 5e-4) is None
+
+    def test_an_empty_solid_rejects_everything(self):
+        from kumiki.cutcsg import EmptyCSG
+
+        rejects = runner._aabb_filter(EmptyCSG(), 5e-4)
+
+        assert rejects is not None
+        assert not rejects([0.0, 0.0, 0.0])
+
+    def test_the_highlight_is_the_same_with_the_filter_as_without(self, mortise_and_tenon_frame):
+        # The point: faster, not different. A broadphase that changed the answer
+        # would be a bug wearing an optimisation's clothes.
+        from kumiki.triangles import triangulate_cutcsg
+
+        cut_timber = _cut_timber_by_name(mortise_and_tenon_frame, "receiving_timber")
+        timber = cut_timber.timber
+        local = cut_timber.render_timber_with_cuts_csg_local()
+        verts = []
+        for triangle in triangulate_cutcsg(local).mesh.triangles:
+            for vertex in triangle:
+                world = timber.transform.local_to_global(
+                    runner._to_v3([float(vertex[i]) for i in range(3)]))
+                verts.extend([float(world[i, 0]) for i in range(3)])
+        indices = list(range(len(verts) // 3))
+        rot, pos = runner._build_inv_transform_float(timber.transform)
+        node = runner._find_csg_by_labels(
+            runner._roots_for_path(cut_timber, ("mortise_hole",))[0][0], ("mortise_hole",))
+
+        with_filter = runner._extract_highlight_mesh(
+            verts, indices, node, rot, pos, 5e-4, root_csg=local)
+
+        original = runner._aabb_filter
+        runner._aabb_filter = lambda csg, eps: None
+        try:
+            without = runner._extract_highlight_mesh(
+                verts, indices, node, rot, pos, 5e-4, root_csg=local)
+        finally:
+            runner._aabb_filter = original
+
+        assert with_filter[0] == without[0]
+        assert with_filter[2] == without[2]

--- a/tests/test_kigumi_csg_navigation.py
+++ b/tests/test_kigumi_csg_navigation.py
@@ -1569,6 +1569,19 @@ class TestHoveringOverAFeature:
 class TestTheBroadphase:
     """Rejecting triangles by a box before asking the CSG about them."""
 
+    def test_an_edge_lights_no_triangles_and_does_not_look_for_any(self):
+        # The line is the edge's highlight. Without the early return the walk
+        # still runs, comparing every triangle against a name no face answers
+        # to, and arrives at nothing the slow way.
+        from kumiki.cutcsg import EmptyCSG
+
+        verts, idx, matched, total = runner._extract_highlight_mesh(
+            [0.0] * 9, [0, 1, 2], EmptyCSG(), None, None, 5e-4,
+            feature_label="a\u00d7b", feature_type="EDGE")
+
+        assert verts == [] and idx == [] and matched == 0
+        assert total == 1
+
     def test_a_box_rejects_what_is_outside_it(self, mortise_and_tenon_frame):
         cut_timber = _cut_timber_by_name(mortise_and_tenon_frame, "receiving_timber")
         local = cut_timber.render_timber_with_cuts_csg_local()


### PR DESCRIPTION
Hovering the mouse shows what a click would take, in the 3D view and in a drawing. Picking got substantially faster along the way.

The branch changed direction partway through, so it is worth reading the commits in order — the first approach is not the one that shipped.

## What it does

Hover is a pick that does not commit. It uses the **click's own handler** — same feature resolution, same mesh, same drilling — and the viewer draws that answer in another colour under the selection. That is the entire difference.

It also follows the click's rules, via the same `choosePickAction`:

- over an **unselected** timber, a click would select the whole timber, so hover asks nothing
- over a **selected** one, a click drills in, so hover shows the feature
- it drills from wherever the CSG focus already is
- it targets the member a click would act on — the **selected** timber wherever it sits along the ray, not the nearest one

## The approach I abandoned

The first version drew an outline computed analytically from the CSG (`region_in_plane` / `segment_on_line`), because it was 20x cheaper than the mesh. It was also wrong in a way that showed: those clip a plane by half spaces, so the result is convex and ignores subtractions. A timber face with eight mortises through it outlined as **one rectangle over the openings**, and a face half cut away outlined at full size.

Hover exists to say what a click would take, so it has to be what a click would take. The analytic path is deleted. `region_in_plane` and `segment_on_line` remain where they belong — measurement anchors and edge highlights — where a feature's *extent* is the question rather than its drawn surface.

## Which made speed the problem, so picking got faster

| | before | after |
|---|---|---|
| a click, end to end | 34.5 ms | **8.2 ms** |
| `rough.front` (whole-beam face) | 25.2 ms | **6.1 ms** |
| `mortise_right` (small feature) | 2.8 ms | **0.4 ms** |

Navigating the CSG tree was never the cost — that is 0.21 ms. It was per-triangle work in highlight extraction:

- **A broadphase.** A triangle whose centroid is outside the target's bounding box cannot be on its boundary. A mortise on a 4.5 m beam keeps 10 triangles of 376. Exact rather than approximate: it is a cheap necessary condition for the test the loop already runs on the same point, with the same epsilon — tested to produce a byte-identical highlight.
- **`_detect_face_label` asked the node for every feature at each triangle** and compared names, when the name is usually a declared feature we can test directly. Legitimate here because the loop has already established the point is on the owner's boundary, which is what makes `test_point` meaningful.
- **A picked edge walked every triangle** comparing against a name no face can answer to, spending a fifth of a second to reach the empty mesh it was always going to reach. An edge's line *is* its highlight.

## Pacing

`hover-state.js`, no DOM or scene, tested on its own. No delay before asking — `settleFrames` defaults to 0, so it asks on the frame the pointer moves.

What paces it is the answer: one question at a time, the next only when the last returns. Answering is not parallel — requests go to a single runner over a pipe — so firing per frame regardless would build a queue answered long after the pointer has gone. Waiting on the answer runs at exactly the rate the runner can sustain, with no number chosen in advance to be wrong on another machine.

A question that never comes back is abandoned after a second, so one failure does not leave hover silent for the session.

## Two bugs found and fixed in here

- The first wiring took the **outer** of two nested things both called `hit`, so it threw *inside the render loop* — which freezes the view rather than showing nothing. `hoverTarget` is now a function with tests pinning the shape, and the render-loop call is guarded, because anything that throws in the frame takes rendering with it.
- The session **swallowed every hover error**, which is why a hover that never worked looked exactly like a hover that found nothing. It logs the first failure now and then stays quiet.

## Also here

`reference` on the pick result — what a measurement would hold for the hovered feature. Once measurement mode exists, hover can say whether this and the anchor already held could be measured, before the click.

## Tests

`1403` pytest, `576` jest, extension `13/13`.