### PR TITLE
Make a measurement by picking

### DIFF
--- a/kigumi/__tests__/hover-state.test.js
+++ b/kigumi/__tests__/hover-state.test.js
@@ -125,6 +125,53 @@ describe('hover pacing', () => {
         expect(patient.due()).not.toBeNull();
     });
 
+    it('an unchanged answer is not drawn again', () => {
+        // The state remembers what it said yes to, so the caller does not keep
+        // a copy beside this one and let the two drift apart.
+        const hover = new HoverState();
+
+        expect(hover.shouldDraw(answer('a'))).toBe(true);
+        expect(hover.shouldDraw(answer('a'))).toBe(false);
+        expect(hover.shouldDraw(answer('b'))).toBe(true);
+    });
+
+    it('clearing forgets what is drawn as well as what is under the pointer', () => {
+        const hover = new HoverState();
+        hover.shouldDraw(answer('a'));
+
+        expect(hover.clear().cleared).toBe(true);
+        expect(hover.shouldDraw(answer('a'))).toBe(true);
+    });
+
+    it('the same place can be asked about again', () => {
+        // The place did not change, the question did -- cycling to the next
+        // feature under the pointer asks the same point a different thing.
+        const hover = new HoverState();
+        hover.moved(100, 100);
+        const first = hover.due();
+        hover.answered(first.request, answer('a'));
+
+        expect(hover.askAgain()).toBe(true);
+        const again = hover.due();
+
+        expect([again.x, again.y]).toEqual([100, 100]);
+        expect(again.request).not.toBe(first.request);
+    });
+
+    it('asking again forgets what is drawn, so the answer is drawn', () => {
+        const hover = new HoverState();
+        hover.moved(100, 100);
+        hover.shouldDraw(answer('a'));
+
+        hover.askAgain();
+
+        expect(hover.shouldDraw(answer('a'))).toBe(true);
+    });
+
+    it('there is nothing to ask again about before the pointer has moved', () => {
+        expect(new HoverState().askAgain()).toBe(false);
+    });
+
     it('clearing forgets what was under the pointer', () => {
         const hover = new HoverState();
         hover.moved(100, 100);

--- a/kigumi/__tests__/measure-mode.test.js
+++ b/kigumi/__tests__/measure-mode.test.js
@@ -1,4 +1,6 @@
-const { MeasureMode, sameReference, STATES } = require('../webview/measure-mode.js');
+const {
+    MeasureMode, couldMeasure, sameReference, STATES,
+} = require('../webview/measure-mode.js');
 
 function face(feature, path = ['cut'], timber = 'post#0') {
     return { pick: { reference: { timber, csgPath: path, feature, type: 'FACE' } } };
@@ -45,12 +47,34 @@ describe('measure mode', () => {
         expect(result.measurement.b.feature).toBe('b');
     });
 
-    it('the measurement belongs to the viewport the first pick was in', () => {
+    it('the measurement belongs to the viewport the second pick was in', () => {
+        // The first may be taken from whichever view shows it best; the
+        // dimension is drawn where the pair was completed.
         const mode = new MeasureMode();
         mode.pick(face('a').pick, 'front');
         mode.pick(face('b').pick, 'top');
 
-        expect(mode.measurement.viewportId).toBe('front');
+        expect(mode.measurement.viewportId).toBe('top');
+    });
+
+    it('re-picking the second end moves the measurement to that view', () => {
+        const mode = new MeasureMode();
+        mode.pick(face('a').pick, 'front');
+        mode.pick(face('b').pick, 'top');
+
+        mode.pick(face('c').pick, 'right');
+
+        expect(mode.measurement.viewportId).toBe('right');
+    });
+
+    it('releasing the second end forgets which view it was in', () => {
+        const mode = new MeasureMode();
+        mode.pick(face('a').pick, 'front');
+        mode.pick(face('b').pick, 'top');
+
+        mode.escape();
+
+        expect(mode.viewportId).toBeNull();
     });
 
     it('a third pick replaces the second rather than making another', () => {
@@ -173,5 +197,77 @@ describe('comparing references', () => {
             edge('mortise_right', 'rough.left').pick.reference,
             face('mortise_right').pick.reference,
         )).toBe(false);
+    });
+});
+
+
+describe('whether a second pick could finish the measurement', () => {
+    const AXES = { look: [0, 1, 0], right: [1, 0, 0], up: [0, 0, 1] };
+    const plane = (normal, at) => ({
+        geometry: { kind: 'plane', normal, at: [0, 0, 0] },
+        at: at || [0, 0, 0],
+    });
+    const nothing = { geometry: null };
+
+    // Stands in for measurements.availableKinds, so this module stays free of
+    // the one that knows about projection.
+    const forms = (one, other) => (
+        one.kind === 'plane' && other.kind === 'plane' ? ['projected_angle'] : []
+    );
+
+    it('says yes when the pair admits something', () => {
+        expect(couldMeasure(plane([0, 0, 1]), plane([1, 0, 0]), AXES, forms).ok).toBe(true);
+    });
+
+    it('says no when the pair admits nothing', () => {
+        const verdict = couldMeasure(plane([0, 0, 1]), { geometry: { kind: 'point' } }, AXES, forms);
+
+        expect(verdict.ok).toBe(false);
+        expect(verdict.reason).toBe('not-measurable');
+    });
+
+    it('a feature lying on no plane or line cannot be measured against', () => {
+        // A cylinder's barrel, a lofted side: good to select, nothing to
+        // measure to, and worth saying before the click rather than after.
+        const verdict = couldMeasure(plane([0, 0, 1]), nothing, AXES, forms);
+
+        expect(verdict.ok).toBe(false);
+        expect(verdict.reason).toBe('not-measurable');
+    });
+
+    it('nothing held is nothing to compare against', () => {
+        expect(couldMeasure(null, plane([0, 0, 1]), AXES, forms).reason).toBe('nothing-held');
+    });
+
+    it('a pair that measures nothing is refused', () => {
+        // Two things in line with each other in this view are a good pair
+        // whose distance is zero, and a dimension reading zero says nothing
+        // while covering what it is drawn over.
+        const value = () => 0;
+
+        const verdict = couldMeasure(
+            plane([0, 0, 1], [0, 0, 0]), plane([1, 0, 0], [0, 0, 0]), AXES, forms, value);
+
+        expect(verdict.ok).toBe(false);
+        expect(verdict.reason).toBe('degenerate');
+    });
+
+    it('a pair that measures something is allowed', () => {
+        const value = () => 0.05;
+
+        expect(couldMeasure(
+            plane([0, 0, 1], [0, 0, 0]), plane([1, 0, 0], [1, 0, 0]), AXES, forms, value,
+        ).ok).toBe(true);
+    });
+
+    it('without positions it cannot tell, and does not pretend to', () => {
+        // No anchor on one of them: the pair is judged on what it admits and
+        // nothing more.
+        const value = () => 0;
+
+        expect(couldMeasure(
+            { geometry: { kind: 'plane', normal: [0, 0, 1] } },
+            plane([1, 0, 0]), AXES, forms, value,
+        ).ok).toBe(true);
     });
 });

--- a/kigumi/frame-view-session.js
+++ b/kigumi/frame-view-session.js
@@ -307,6 +307,18 @@ class FrameViewSession {
                 });
                 return;
             }
+            if (message.type === 'measurePickAtPoint') {
+                this._handleMeasurePickAtPoint(message).catch((err) => {
+                    this.log(`[measure] pick failed: ${err.message || err}`);
+                });
+                return;
+            }
+            if (message.type === 'addMeasurement') {
+                this._handleAddMeasurement(message).catch((err) => {
+                    this.log(`[measure] ${err.message || err}`);
+                });
+                return;
+            }
             if (message.type === 'hoverFeatureAtPoint') {
                 // Reported once and then not again. This fires while the
                 // pointer moves, so logging every failure would bury the log --
@@ -973,6 +985,33 @@ class FrameViewSession {
         };
         const result = await this.runnerSession.slotRequest('find_csg_at_point', this.slotName, payload);
         this._postToWebview({ type: 'csgSelectionResult', ...result });
+    }
+
+    async _handleMeasurePickAtPoint(message) {
+        if (!this.runnerSession) {
+            return;
+        }
+        const result = await this.runnerSession.slotRequest('hover_feature_at_point', this.slotName, {
+            memberKey: message.memberKey,
+            point: message.point,
+            currentPath: message.currentPath || [],
+            ctrlClick: false,
+        });
+        this._postToWebview({ type: 'measurePickResult', ...result });
+    }
+
+    async _handleAddMeasurement(message) {
+        // Through the same path every other drawings command takes, so the
+        // whole set comes back as a 'scenes' message and the tree and the sheet
+        // redraw from one answer. Posting a shape of its own is how a
+        // measurement gets made and never appears.
+        await this._handleDrawingsCommand('add_measurement', {
+            drawingId: message.drawingId,
+            viewportId: message.viewportId,
+            a: message.a,
+            b: message.b,
+            kind: message.kind || null,
+        }, { enter: false });
     }
 
     async _handleHoverFeatureAtPoint(message) {

--- a/kigumi/runner.py
+++ b/kigumi/runner.py
@@ -4190,6 +4190,77 @@ def _extract_highlight_mesh(
     return out_verts, out_idx, matched, total_tris
 
 
+def _pick_from_candidate(local_csg: Any, hit: Any):
+    """Everything a pick needs, for one chosen feature at the point.
+
+    Returns (path, node, label, type, edge) or None when the feature's owner
+    cannot be placed in the tree, which leaves the caller with what it had.
+    """
+    from kumiki.cutcsg import CSGFeatureType
+
+    feature = hit.feature
+    if feature.feature_type() == CSGFeatureType.EDGE:
+        owned = _edge_owner(local_csg, feature)
+        if owned is None:
+            return None
+        return (owned[1], owned[0], feature.name, "EDGE", feature)
+
+    positions = _node_positions(local_csg)
+    placed = positions.get(id(hit.owner))
+    if placed is None:
+        return None
+    return (placed[2], hit.owner, feature.name, feature.feature_type().name, None)
+
+
+def _picked_anchor(
+    feature_hits: List[Any],
+    timber: Any,
+    feature_label: Optional[str],
+    edge: Any,
+    owner: Any,
+) -> Optional[List[float]]:
+    """Where a dimension to what was picked would attach, in world space.
+
+    The same anchor a measurement would resolve to, so what the viewer measures
+    while deciding is what it will measure once decided.
+    """
+    if feature_label is None:
+        return None
+    if edge is not None:
+        return _feature_anchor(edge, owner, timber, edge.locate(owner))
+    hit = next((h for h in feature_hits if h.feature.name == feature_label), None)
+    if hit is None:
+        return None
+    return _feature_anchor(hit.feature, hit.owner, timber, hit.feature.locate(hit.owner))
+
+
+def _picked_geometry(
+    feature_hits: List[Any],
+    timber: Any,
+    feature_label: Optional[str],
+    edge: Any,
+    owner: Any,
+) -> Optional[Dict[str, Any]]:
+    """The unbounded geometry of what was picked, in world space, or None.
+
+    None for a feature lying on no plane or line -- a cylinder's barrel, a
+    lofted side. Those are good to select and cannot be measured against, which
+    the viewer needs to be able to say BEFORE the click rather than after.
+
+    Sent as geometry rather than as a verdict because what decides whether a
+    pair can be dimensioned is what each of them PROJECTS to, and only the
+    viewer knows which direction it is looking from.
+    """
+    if feature_label is None:
+        return None
+    if edge is not None:
+        return _located_geometry_payload(edge.locate(owner), timber)
+    hit = next((h for h in feature_hits if h.feature.name == feature_label), None)
+    if hit is None:
+        return None
+    return _located_geometry_payload(hit.feature.locate(hit.owner), timber)
+
+
 def _handle_hover_feature_at_point(
     state: RunnerState, payload: Dict[str, Any], slot_state: Optional['SlotState'] = None,
 ) -> Dict[str, Any]:
@@ -4267,6 +4338,23 @@ def _handle_find_csg_at_point(state: RunnerState, payload: Dict[str, Any], slot_
     feature_type = None
     feature_hits = _features_at_point(local_csg, local_pt, eps)
     edge = _resolve_derived_edge(feature_hits) if feature_label is not None else None
+
+    # Which of the features at this point is wanted, when more than one is.
+    #
+    # The best answer is the most specific -- an edge beats the two faces that
+    # form it -- and that is right for a click that means "this thing here". It
+    # is wrong when what you want is one of those faces. A face seen edge-on in
+    # an elevation, which is the one you most often measure to, is never the
+    # best answer anywhere: it shows as a line, and on that line the edge wins.
+    #
+    # So the caller can ask for the next one instead, and the count goes back so
+    # it knows how many there are to cycle through.
+    candidate_index = int(payload.get("candidateIndex") or 0)
+    if candidate_index and feature_hits:
+        chosen = feature_hits[candidate_index % len(feature_hits)]
+        picked = _pick_from_candidate(local_csg, chosen)
+        if picked is not None:
+            new_path, target_csg, feature_label, feature_type, edge = picked
     if edge is not None:
         owned = _edge_owner(local_csg, edge)
         if owned is not None:
@@ -4330,9 +4418,20 @@ def _handle_find_csg_at_point(state: RunnerState, payload: Dict[str, Any], slot_
         # because only the runner can see the CSG a path has to be read against
         # -- an edge in particular is not a feature anyone declared, so it has
         # to name the two faces that form it.
+        "candidateCount": len(feature_hits),
         "reference": _pick_reference(
             local_csg, member_key, new_path, feature_label, feature_type, edge,
         ),
+        # Where the feature is, unbounded, in world space. What decides whether
+        # a pair can be dimensioned is what each PROJECTS to, and only the
+        # viewer knows the direction it is looking from -- so it gets the plane
+        # or the line and works that out itself.
+        "geometry": _picked_geometry(feature_hits, timber, feature_label, edge, target_csg),
+        # And where a dimension would attach, which is what makes the difference
+        # between a pair that admits a measurement and one that admits a
+        # measurement of nothing: two edges in line with each other are a
+        # perfectly good pair whose distance is zero.
+        "at": _picked_anchor(feature_hits, timber, feature_label, edge, target_csg),
         # What was selected, and the feature within it if navigation resolved
         # one. feature_label is None while a click is still drilling down
         # through compounds, and the display has to say so rather than name a

--- a/kigumi/webview/hover-state.js
+++ b/kigumi/webview/hover-state.js
@@ -64,7 +64,10 @@
         reset() {
             /** What is under the pointer, as the runner answered. */
             this.feature = null;
+            /** Where the pointer is, in canvas coordinates. */
             this.at = null;
+            /** What is currently drawn for it, so an unchanged answer is not redrawn. */
+            this.drawn = null;
             this._pending = null;
             this._asked = 0;
             this._outstanding = false;
@@ -150,9 +153,39 @@
             return { kept: true, feature: this.feature };
         }
 
+        /**
+         * Ask about the same place again, without the pointer having moved.
+         *
+         * For when the question changed rather than the place -- cycling to the
+         * next feature under the pointer asks the same point a different thing.
+         */
+        askAgain() {
+            if (this.at === null) {
+                return false;
+            }
+            this._pending = { x: this.at.x, y: this.at.y };
+            this._stillFrames = 0;
+            this.drawn = null;
+            return true;
+        }
+
+        /**
+         * Whether an answer is worth drawing, given what is drawn already.
+         *
+         * Remembers what it says yes to, so the caller does not have to keep a
+         * copy of the last answer beside this one and keep the two in step.
+         */
+        shouldDraw(feature) {
+            if (HoverState.sameFeature(this.drawn, feature)) {
+                return false;
+            }
+            this.drawn = feature;
+            return true;
+        }
+
         /** The pointer left, or the mode changed: hold nothing. */
         clear() {
-            const had = this.feature !== null;
+            const had = this.feature !== null || this.drawn !== null;
             this.reset();
             return { cleared: had };
         }

--- a/kigumi/webview/measure-mode.js
+++ b/kigumi/webview/measure-mode.js
@@ -21,7 +21,8 @@
     //   state     input     goes to    and
     //   -------   -------   --------   ---------------------------------------
     //   OFF       pick A    FROM       A is held
-    //   FROM      pick B    BETWEEN    the measurement A-B is made
+    //   FROM      pick B    BETWEEN    the measurement A-B is made, in B's
+    //                                  viewport
     //   FROM      escape    OFF        A released, mode left
     //   BETWEEN   pick C    BETWEEN    B replaced by C; the SAME measurement
     //                                  now reads A-C. For a misclick, so it
@@ -38,6 +39,27 @@
     // there is no plain "look at this one" selection while in a drawing. Both
     // feature and measurement selections are cleared when the mode changes, so
     // nothing is left highlighted that the current mode cannot act on.
+    //
+    //
+    // WHICH VIEWPORT IT BELONGS TO
+    //
+    // The second pick's. The first may be taken from any view -- whichever one
+    // shows that feature best -- and the dimension is drawn where the pair was
+    // completed. Re-picking the second end moves it, since that pick is the one
+    // that decides.
+    //
+    // It has to be one of them rather than both, because a dimension is a
+    // projection and only means anything in the plane it is projected onto. And
+    // it is the second because that is the one you are looking at when you
+    // finish, which is the view you meant to draw it in.
+
+    /**
+     * Below this a measurement measures nothing, in world units.
+     *
+     * The same threshold the sheet uses to decline drawing a dimension, so a
+     * pair refused here and one drawn as broken agree about what is too small.
+     */
+    const DEGENERATE = 1e-6;
 
     const OFF = 'off';
     const FROM = 'from';
@@ -65,7 +87,10 @@
             this.state = OFF;
             this.from = null;
             this.to = null;
-            /** The viewport the first pick landed in; the measurement lives there. */
+            this.fromGeometry = null;
+            this.toGeometry = null;
+            this.fromAt = null;
+            /** Where the second pick landed. The measurement is drawn there. */
             this.viewportId = null;
         }
 
@@ -96,7 +121,8 @@
 
             if (this.state === OFF) {
                 this.from = reference;
-                this.viewportId = viewportId === undefined ? null : viewportId;
+                this.fromGeometry = pick.geometry || null;
+                this.fromAt = pick.at || null;
                 this.state = FROM;
                 return { action: 'from' };
             }
@@ -110,6 +136,9 @@
 
             const replacing = this.state === BETWEEN;
             this.to = reference;
+            this.toGeometry = pick.geometry || null;
+            // The second pick decides where it is drawn, so re-picking moves it.
+            this.viewportId = viewportId === undefined ? null : viewportId;
             this.state = BETWEEN;
             return {
                 action: replacing ? 'replaced' : 'to',
@@ -121,6 +150,8 @@
         escape() {
             if (this.state === BETWEEN) {
                 this.to = null;
+                this.toGeometry = null;
+                this.viewportId = null;
                 this.state = FROM;
                 return { action: 'released-to' };
             }
@@ -170,8 +201,49 @@
         ];
     }
 
+    /**
+     * Whether a second pick could complete a measurement with the first.
+     *
+     * Answered per VIEWPORT, because a dimension is a projection: two faces at
+     * an angle are an angle in one view and cover each other in another. That
+     * is also why it is the second pick that decides which viewport the
+     * measurement belongs to -- the answer depends on where you are standing.
+     *
+     * `axes` is that viewport's, and `kinds` is measurements.availableKinds
+     * passed in rather than reached for, so this stays free of the module that
+     * knows about projection.
+     */
+    function couldMeasure(held, candidate, axes, forms, value) {
+        if (!held || !candidate) {
+            return { ok: false, reason: 'nothing-held' };
+        }
+        if (!held.geometry || !candidate.geometry) {
+            // A cylinder's barrel, a lofted side: good to select, nothing to
+            // measure against, and worth saying before the click rather than
+            // after.
+            return { ok: false, reason: 'not-measurable' };
+        }
+        const available = forms(held.geometry, candidate.geometry, axes);
+        if (!available || available.length === 0) {
+            return { ok: false, reason: 'not-measurable' };
+        }
+        // A pair can admit a measurement and admit a measurement of nothing.
+        // Two edges in line with each other in this view are a good pair whose
+        // distance is zero, and a dimension reading zero is not worth drawing:
+        // it says nothing and covers what it is drawn over.
+        if (value && held.at && candidate.at) {
+            const size = value(available[0], held.at, candidate.at, held.geometry,
+                               candidate.geometry, axes);
+            if (size !== null && Math.abs(size) < DEGENERATE) {
+                return { ok: false, reason: 'degenerate', kinds: available };
+            }
+        }
+        return { ok: true, kinds: available };
+    }
+
     const KigumiMeasureMode = {
         MeasureMode,
+        couldMeasure,
         sameReference,
         referenceKey,
         pickIsMeasurable,

--- a/kigumi/webview/viewer-app.js
+++ b/kigumi/webview/viewer-app.js
@@ -278,8 +278,36 @@ const CSG_HIGHLIGHT_COLORS = Object.freeze({
 // What the pointer is over, as opposed to what is selected. A different hue as
 // well as a different shape -- an outline rather than a fill -- so the two
 // never read as the same state.
+/**
+ * Every triangle edge of a mesh, as line-segment positions.
+ *
+ * So a face still shows when it projects to a line: seen exactly edge-on it has
+ * no area to shade, and the mesh renders as nothing, while its boundary is
+ * still there to draw.
+ */
+function _meshEdgePositions(vertices, indices) {
+    const out = [];
+    const at = (index) => [vertices[index * 3], vertices[index * 3 + 1], vertices[index * 3 + 2]];
+    const list = indices || [];
+    for (let triangle = 0; triangle + 2 < list.length; triangle += 3) {
+        const corners = [list[triangle], list[triangle + 1], list[triangle + 2]];
+        for (let side = 0; side < 3; side += 1) {
+            out.push(...at(corners[side]), ...at(corners[(side + 1) % 3]));
+        }
+    }
+    return out;
+}
+
 const HOVER_COLOR = 0xffa726;
+// Shown while measuring, for a feature that could not finish the measurement
+// from where you are looking. Said in colour rather than by refusing the click,
+// since the answer depends on the view and the useful thing is to see that.
+const HOVER_REFUSED_COLOR = 0xef5350;
 const HOVER_OPACITY = 0.55;
+// The feature a measurement is being taken from, while the other end is chosen.
+// Its own colour: it is neither hovered nor selected, it is held.
+const HELD_COLOR = 0x66bb6a;
+const HELD_OPACITY = 0.6;
 
 // A selected edge is drawn as a line rather than shaded like a face, so it
 // needs a width of its own -- several times the timbers' own edge lines, or the
@@ -2558,6 +2586,11 @@ class KigumiViewerApp extends LitElement {
             return;
         }
 
+        if (message.type === 'measurePickResult') {
+            this._measurePicked(message);
+            return;
+        }
+
         if (message.type === 'csgSelectionResult') {
             this.handleCSGSelectionResult(message);
             return;
@@ -2889,6 +2922,28 @@ class KigumiViewerApp extends LitElement {
     }
 
     onWindowKeyDown(event) {
+        // Tab is checked before the defaultPrevented guard: it is the focus
+        // key, so something else may well have claimed it already, and this
+        // only acts while the pointer is over a feature -- which is not a
+        // moment anyone is tabbing between controls.
+        if (event.key === 'Tab' && this._hover && this._hover.feature) {
+            // Step to the next feature under the pointer. A face seen edge-on
+            // is never the best answer where it lies -- the edge formed with it
+            // wins -- so without this it cannot be reached at all, and in an
+            // elevation it is the one most worth measuring to.
+            event.preventDefault();
+            const count = Math.max(1, this._hover.feature.candidateCount || 1);
+            this._candidateIndex = ((this._candidateIndex || 0) + 1) % count;
+            this.emitViewerLog('measure-cycle', {
+                index: this._candidateIndex,
+                of: count,
+                from: this._hover.feature.featureLabel,
+            });
+            // The place did not change, the question did: ask the same point
+            // again so the hover shows what the next click would now take.
+            this._hover.askAgain();
+            return;
+        }
         if (event.defaultPrevented) {
             return;
         }
@@ -2896,6 +2951,14 @@ class KigumiViewerApp extends LitElement {
             event.preventDefault();
             if (this.contextMenuState) {
                 this.closeMemberContextMenu();
+            } else if (this._measureMode && this._measureMode.isActive) {
+                // One end at a time, so leaving a half-made measurement takes
+                // two presses: the second feature, then the mode.
+                const released = this._measureMode.escape();
+                if (released.action === 'left') {
+                    this.clearHeldFeature();
+                }
+                this.emitViewerLog('measure-escape', { action: released.action });
             } else if (this.selectionManager.csgFocus) {
                 this._dropCsgFocus();
             } else {
@@ -3027,8 +3090,14 @@ class KigumiViewerApp extends LitElement {
         if (!this._hover) {
             this._hover = new window.KigumiHover.HoverState();
         }
-        this._hoverClient = { x: event.clientX, y: event.clientY };
-        this._hover.moved(event.clientX, event.clientY);
+        // Where the pointer is lives on the hover state, which tracks it
+        // anyway to decide whether a move was worth anything.
+        const result = this._hover.moved(event.clientX, event.clientY);
+        if (result.reason !== 'barely-moved') {
+            // Cycling is about one place. Move somewhere else and it starts
+            // again at the best answer there.
+            this._candidateIndex = 0;
+        }
     }
 
     /**
@@ -3043,7 +3112,7 @@ class KigumiViewerApp extends LitElement {
             return;
         }
         const due = this._hover.due();
-        if (!due || !this._hoverClient) {
+        if (!due) {
             return;
         }
         // The same decision a click makes, so hover shows what a click would do
@@ -3054,7 +3123,7 @@ class KigumiViewerApp extends LitElement {
         // The decision also says WHICH member, which is not the nearest one: a
         // click drills into the selected timber wherever it sits along the ray.
         const decision = choosePickAction({
-            hits: this._findMembersAlongRay(this._hoverClient.x, this._hoverClient.y),
+            hits: this._findMembersAlongRay(due.x, due.y),
             selectedTimbers: this.selectionManager.selectedTimbers,
             shiftKey: false,
         });
@@ -3076,6 +3145,7 @@ class KigumiViewerApp extends LitElement {
             point: target.point,
             currentPath,
             ctrlClick: false,
+            candidateIndex: this._candidateIndex || 0,
             request: due.request,
         });
     }
@@ -3089,11 +3159,11 @@ class KigumiViewerApp extends LitElement {
         if (!kept.kept) {
             return;
         }
-        if (window.KigumiHover.HoverState.sameFeature(this._hoverDrawn, message)) {
+        if (!this._hover.shouldDraw(message)) {
             return;
         }
-        this._hoverDrawn = message;
-        this.drawHoverHighlight(message);
+        this.drawHoverHighlight(message, this._measureVerdict(message).ok
+            ? HOVER_COLOR : HOVER_REFUSED_COLOR);
     }
 
     /**
@@ -3105,17 +3175,73 @@ class KigumiViewerApp extends LitElement {
      * an outline taken from the CSG was convex, so a timber face with mortises
      * through it lit as a whole rectangle over the openings.
      */
-    drawHoverHighlight(message) {
+    /**
+     * Whether a feature could finish the measurement in hand, from a given view.
+     *
+     * One answer for two callers: the hover paints by it, and the click refuses
+     * by it. Two judgements would eventually disagree, and a feature drawn red
+     * that the click then accepted would be worse than either on its own.
+     *
+     * `{ok: true}` when nothing is held -- the first pick is always allowed,
+     * since there is nothing yet for it to be wrong about.
+     */
+    _measureVerdict(message, viewport) {
+        const mode = this._measureMode;
+        if (!mode || mode.state !== window.KigumiMeasureMode.STATES.FROM) {
+            // Nothing held, so nothing to be wrong against -- but a feature
+            // that can never be measured to is still no good as a first pick.
+            // Taking one leaves the measurement unfinishable: every second pick
+            // is then refused, and the refusal is about the pick you just made
+            // rather than the one you made a minute ago, which reads as the
+            // click doing nothing.
+            //
+            // A feature with no plane or line has nothing to measure against; a
+            // feature nobody declared cannot be referred to afterwards, so a
+            // dimension to it could not be saved.
+            if (!message || !message.geometry || !message.reference) {
+                return { ok: false, reason: 'unmeasurable-feature' };
+            }
+            return { ok: true, reason: 'nothing-held' };
+        }
+        const at = viewport === undefined
+            ? (this._hover && this._hover.at ? this._resolvePointer(this._hover.at.x, this._hover.at.y) : null)
+            : viewport;
+        if (!at) {
+            return { ok: true, reason: 'no-viewport' };
+        }
+        const axes = this.viewportAxes(at.viewport || at);
+        return window.KigumiMeasureMode.couldMeasure(
+            { geometry: mode.fromGeometry, at: mode.fromAt }, message, axes,
+            (one, other, viewAxes) => KigumiMeasurements.availableKinds(
+                KigumiMeasurements.projectedForm(one, viewAxes.look),
+                KigumiMeasurements.projectedForm(other, viewAxes.look),
+            ),
+            (kind, fromAt, toAt, one, other, viewAxes) => {
+                const measured = KigumiMeasurements.measureValue(
+                    kind, fromAt, toAt,
+                    KigumiMeasurements.projectedForm(one, viewAxes.look),
+                    KigumiMeasurements.projectedForm(other, viewAxes.look),
+                    viewAxes,
+                );
+                // An angle of zero is two things in line, which is as much a
+                // measurement of nothing as a distance of zero.
+                return measured ? measured.value : null;
+            },
+        );
+    }
+
+    drawHoverHighlight(message, color) {
         this.clearHoverOutline();
         const mesh = message.highlightMesh;
         const edge = message.highlightEdge;
+        const shade = color === undefined ? HOVER_COLOR : color;
 
         if (edge && Array.isArray(edge.start) && Array.isArray(edge.end)) {
-            this._buildHoverEdgeLine(edge.start, edge.end);
+            this._buildHoverEdgeLine(edge.start, edge.end, shade);
         }
         if (mesh && Array.isArray(mesh.vertices) && mesh.vertices.length > 0) {
             this._buildHighlightMesh(
-                mesh.vertices, mesh.indices, HOVER_COLOR, HOVER_OPACITY, '_hoverHighlightMesh',
+                mesh.vertices, mesh.indices, shade, HOVER_OPACITY, '_hoverHighlightMesh',
             );
             // Under the selection's own highlight, which sits at 999: what is
             // selected outranks what is merely under the pointer.
@@ -3125,11 +3251,11 @@ class KigumiViewerApp extends LitElement {
         }
     }
 
-    _buildHoverEdgeLine(start, end) {
+    _buildHoverEdgeLine(start, end, color) {
         const geometry = new THREE.LineSegmentsGeometry();
         geometry.setPositions([...start, ...end]);
         const material = new THREE.LineMaterial({
-            color: HOVER_COLOR,
+            color: color === undefined ? HOVER_COLOR : color,
             linewidth: CSG_HIGHLIGHT_EDGE_WIDTH_PX,
             resolution: this._getRendererResolution(),
             depthTest: false,
@@ -3144,7 +3270,9 @@ class KigumiViewerApp extends LitElement {
     }
 
     clearHoverOutline() {
-        this._hoverDrawn = null;
+        if (this._hover) {
+            this._hover.drawn = null;
+        }
         this._disposeHighlightMesh('_hoverHighlightMesh');
         this._disposeHighlightMesh('_hoverHighlightEdge');
     }
@@ -3154,8 +3282,203 @@ class KigumiViewerApp extends LitElement {
         if (this._hover) {
             this._hover.clear();
         }
-        this._hoverClient = null;
         this.clearHoverOutline();
+    }
+
+    // -------------------------------------------------------------------------
+    // Measurement mode: making a dimension by picking
+    // -------------------------------------------------------------------------
+
+    get measureMode() {
+        if (!this._measureMode) {
+            this._measureMode = new window.KigumiMeasureMode.MeasureMode();
+        }
+        return this._measureMode;
+    }
+
+    /**
+     * A click inside a drawing. Returns whether measurement mode took it.
+     *
+     * Inside a drawing there is no plain "look at this feature" selection --
+     * picking a feature is how a measurement starts. Outside one, this does
+     * nothing and the click means what it always meant.
+     */
+    handleMeasurePick(event, hits) {
+        if (!this.drawingBetaEnabled || !this.isInDrawing) {
+            return false;
+        }
+        const resolved = this._resolvePointer(event.clientX, event.clientY);
+        const viewportId = resolved ? resolved.viewport.id : null;
+        const decision = choosePickAction({
+            hits,
+            selectedTimbers: this.selectionManager.selectedTimbers,
+            shiftKey: false,
+        });
+        const target = window.KigumiHover.hoverTarget(decision);
+        if (!target) {
+            return false;
+        }
+        // The pick has to come back from the runner before the mode can act on
+        // it: only python can say which feature a point is on. So the click is
+        // sent as a hover would be, and _measurePicked continues once it lands.
+        this._measurePendingViewport = viewportId;
+        // Kept as well as its id: judging the pick needs the viewport's axes.
+        this._measurePendingViewportObject = resolved;
+        if (typeof vscode !== 'undefined') {
+            // Its own message rather than borrowing the hover one: the two ask
+            // the same question but mean different things, and a hover answer
+            // arriving mid-measurement must not be mistaken for a click.
+            vscode.postMessage({
+                type: 'measurePickAtPoint',
+                memberKey: target.memberKey,
+                point: target.point,
+                currentPath: [],
+                ctrlClick: false,
+                // Whatever the hover is showing is what the click takes.
+                candidateIndex: this._candidateIndex || 0,
+            });
+        }
+        return true;
+    }
+
+    /**
+     * Show the feature a measurement is being taken from.
+     *
+     * The mesh, and its edges as well. A face seen exactly edge-on -- which is
+     * the usual case in an elevation, and the case where measuring to it makes
+     * most sense -- projects to a line with no area, so the mesh alone renders
+     * as nothing at all. Its boundary still projects to that line, so drawing
+     * the edges keeps it visible from any direction.
+     */
+    drawHeldFeature(message) {
+        this.clearHeldFeature();
+        const mesh = message && message.highlightMesh;
+        const edge = message && message.highlightEdge;
+
+        if (edge && Array.isArray(edge.start) && Array.isArray(edge.end)) {
+            const geometry = new THREE.LineSegmentsGeometry();
+            geometry.setPositions([...edge.start, ...edge.end]);
+            this._addHeldLine(geometry);
+        }
+        if (mesh && Array.isArray(mesh.vertices) && mesh.vertices.length > 0) {
+            this._buildHighlightMesh(
+                mesh.vertices, mesh.indices, HELD_COLOR, HELD_OPACITY, '_heldFeatureMesh',
+            );
+            if (this._heldFeatureMesh) {
+                this._heldFeatureMesh.renderOrder = 902;
+            }
+            const outline = new THREE.LineSegmentsGeometry();
+            outline.setPositions(_meshEdgePositions(mesh.vertices, mesh.indices));
+            this._addHeldLine(outline);
+        }
+    }
+
+    _addHeldLine(geometry) {
+        const material = new THREE.LineMaterial({
+            color: HELD_COLOR,
+            linewidth: CSG_HIGHLIGHT_EDGE_WIDTH_PX,
+            resolution: this._getRendererResolution(),
+            depthTest: false,
+            transparent: true,
+        });
+        const line = new THREE.LineSegments2(geometry, material);
+        line.computeLineDistances();
+        line.renderOrder = 903;
+        this.scene.add(line);
+        this._heldFeatureLine = line;
+    }
+
+    clearHeldFeature() {
+        this._disposeHighlightMesh('_heldFeatureMesh');
+        this._disposeHighlightMesh('_heldFeatureLine');
+    }
+
+    /** A pick came back while measuring. Offers it to the mode. */
+    _measurePicked(message) {
+        // Judged before the mode sees it, by the same rule the hover painted
+        // it with: a feature shown red is not one you can pick. Refusing here
+        // rather than in MeasureMode keeps projection out of the state
+        // machine, which is what makes that testable without a viewport.
+        const verdict = this._measureVerdict(message, this._measurePendingViewportObject);
+        if (!verdict.ok) {
+            this.emitViewerLog('measure-pick', {
+                feature: message.featureLabel,
+                type: message.featureType,
+                candidates: message.candidateCount,
+                action: 'refused',
+                reason: verdict.reason,
+            });
+            this.reportMeasureRefusal(verdict.reason, message);
+            return;
+        }
+        const result = this.measureMode.pick(message, this._measurePendingViewport);
+        this.emitViewerLog('measure-pick', {
+            feature: message.featureLabel,
+            type: message.featureType,
+            candidates: message.candidateCount,
+            action: result.action,
+            reason: result.reason,
+        });
+        if (result.action === 'refused') {
+            this.reportMeasureRefusal(result.reason, message);
+            return;
+        }
+        if (result.action === 'from') {
+            // Shown, so it is clear what the measurement is being taken FROM
+            // while the second end is being chosen.
+            this.drawHeldFeature(message);
+            this.emitViewerLog('measure-from', { feature: message.featureLabel });
+            return;
+        }
+        this.commitMeasurement(result.measurement);
+    }
+
+    /**
+     * Say why a pick cannot be measured, rather than doing nothing.
+     *
+     * A click that silently achieves nothing is the worst of the options: it
+     * looks like the viewer missed the click.
+     */
+    reportMeasureRefusal(reason, message) {
+        const said = {
+            'no-feature': 'nothing to measure here yet -- the click is still on its way in',
+            'same-feature': 'that is the feature already held; pick a different one',
+            'not-measurable': 'nothing can be dimensioned between those two in this view '
+                + '-- try another view, or another feature',
+            'degenerate': 'those two are in line in this view, so the measurement would be '
+                + 'zero -- try another view, or another feature',
+            'unmeasurable-feature': 'that one cannot be measured to -- it has no plane or line '
+                + 'of its own, or it is a face nobody named. Tab steps to the next feature '
+                + 'under the pointer',
+        }[reason] || reason;
+        this.emitViewerLog('measure-refused', { reason, said, feature: message && message.featureLabel });
+        if (typeof vscode !== 'undefined') {
+            vscode.postMessage({ type: 'log', text: `[measure] ${said}` });
+        }
+    }
+
+    /** Send a finished measurement to be held in the file tier. */
+    commitMeasurement(measurement) {
+        if (!measurement || typeof vscode === 'undefined') {
+            return;
+        }
+        vscode.postMessage({
+            type: 'addMeasurement',
+            drawingId: this.sceneStore.activeSceneId,
+            viewportId: measurement.viewportId,
+            a: measurement.a,
+            b: measurement.b,
+        });
+    }
+
+    /** Leaving a drawing, or changing mode: hold nothing, show nothing held. */
+    clearMeasureMode() {
+        if (this._measureMode) {
+            this._measureMode.leave();
+        }
+        this.clearHeldFeature();
+        this._measurePendingViewport = null;
+        this._measurePendingViewportObject = null;
     }
 
     handleCanvasClick(event) {
@@ -3163,6 +3486,11 @@ class KigumiViewerApp extends LitElement {
             return;
         }
         const hits = this._findMembersAlongRay(event.clientX, event.clientY);
+        // Inside a drawing, picking a feature starts a measurement rather than
+        // selecting it. There is no plain "look at this one" there.
+        if (this.handleMeasurePick(event, hits)) {
+            return;
+        }
         const decision = choosePickAction({
             hits,
             selectedTimbers: this.selectionManager.selectedTimbers,
@@ -5736,6 +6064,15 @@ class KigumiViewerApp extends LitElement {
         if (!this.sceneStore.setActiveScene(sceneId)) {
             return;
         }
+        // Nothing held carries across a change of mode. A feature selected in
+        // the model means nothing in a drawing, a half-made measurement means
+        // nothing outside one, and either left lit would be something the new
+        // mode cannot act on.
+        this.clearMeasureMode();
+        this.clearHover();
+        // Clears whatever is focused, feature or measurement -- they are one
+        // field, so this is both.
+        this._dropCsgFocus();
         this.rebuildViewports();
         this.syncCameraControls();
         this.applySceneBackground();

--- a/kumiki/cutcsg.py
+++ b/kumiki/cutcsg.py
@@ -134,9 +134,15 @@ class CSGFeatureType(Enum):
 # plus, for edges and points, however far a human click lands from a target it
 # cannot hit exactly. Code doing exact analytic work wants
 # FeatureTestTolerances.exact() instead.
+#
+# Edges and points are roomier again than the reasoning above alone would give
+# them, because they are what a measurement is usually taken to: a dimension
+# runs to an arris or a corner far more often than to the middle of a face, and
+# a snap that keeps missing is worse than one that occasionally takes the
+# neighbouring edge -- which the specificity ordering then sorts out.
 FEATURE_FACE_TOLERANCE = scalar('5e-4')
-FEATURE_EDGE_TOLERANCE = scalar('2e-3')
-FEATURE_POINT_TOLERANCE = scalar('4e-3')
+FEATURE_EDGE_TOLERANCE = scalar('4e-3')
+FEATURE_POINT_TOLERANCE = scalar('8e-3')
 
 
 @dataclass(frozen=True)

--- a/tests/test_kigumi_csg_navigation.py
+++ b/tests/test_kigumi_csg_navigation.py
@@ -1649,3 +1649,90 @@ class TestTheBroadphase:
 
         assert with_filter[0] == without[0]
         assert with_filter[2] == without[2]
+
+
+class TestChoosingAmongTheFeaturesAtAPoint:
+    """Reaching a face that is never the best answer anywhere.
+
+    A face seen edge-on shows as a line, and on that line the edge formed with
+    it wins -- an edge is the more specific answer, which is right for a click
+    meaning "this thing here" and wrong when the face is what you want. In an
+    elevation that face is the one you most often measure to.
+    """
+
+    def _slot(self, frame, member):
+        from kumiki.triangles import triangulate_cutcsg
+
+        cut_timber = _cut_timber_by_name(frame, member)
+        timber = cut_timber.timber
+        local = cut_timber.render_timber_with_cuts_csg_local()
+        vertices = []
+        for triangle in triangulate_cutcsg(local).mesh.triangles:
+            for vertex in triangle:
+                world = timber.transform.local_to_global(
+                    runner._to_v3([float(vertex[i]) for i in range(3)]))
+                vertices.extend([float(world[i, 0]) for i in range(3)])
+        mesh = {"vertices": vertices, "indices": list(range(len(vertices) // 3))}
+
+        class Slot:
+            mesh_cache = {member: {"local_csg": local, "cut_timber": cut_timber, "mesh": mesh}}
+
+        class State:
+            _active = Slot()
+
+        return State(), Slot(), local, cut_timber, vertices
+
+    def _at_an_edge(self, frame, member):
+        from kumiki.cutcsg import CSGFeatureType
+
+        state, slot, local, cut_timber, vertices = self._slot(frame, member)
+        for index in range(0, len(vertices), 3):
+            point = vertices[index:index + 3]
+            payload = {"memberKey": member, "point": point,
+                       "currentPath": [], "ctrlClick": False}
+            first = runner._handle_find_csg_at_point(state, dict(payload), slot)
+            if first.get("featureType") == "EDGE" and first.get("candidateCount", 0) > 1:
+                return state, slot, payload, first
+        raise AssertionError("no point offered an edge and something else")
+
+    def test_the_edge_is_what_a_plain_click_takes(self, mortise_and_tenon_frame):
+        _state, _slot, _payload, first = self._at_an_edge(
+            mortise_and_tenon_frame, "receiving_timber")
+
+        assert first["featureType"] == "EDGE"
+
+    def test_asking_for_the_next_one_reaches_a_face(self, mortise_and_tenon_frame):
+        state, slot, payload, first = self._at_an_edge(
+            mortise_and_tenon_frame, "receiving_timber")
+
+        second = runner._handle_find_csg_at_point(
+            state, dict(payload, candidateIndex=1), slot)
+
+        assert second["featureLabel"] != first["featureLabel"]
+        assert second["reference"] is not None
+
+    def test_the_count_says_how_many_there_are_to_cycle(self, mortise_and_tenon_frame):
+        _state, _slot, _payload, first = self._at_an_edge(
+            mortise_and_tenon_frame, "receiving_timber")
+
+        assert first["candidateCount"] >= 2
+
+    def test_cycling_past_the_end_comes_back_round(self, mortise_and_tenon_frame):
+        state, slot, payload, first = self._at_an_edge(
+            mortise_and_tenon_frame, "receiving_timber")
+        count = first["candidateCount"]
+
+        wrapped = runner._handle_find_csg_at_point(
+            state, dict(payload, candidateIndex=count), slot)
+
+        assert wrapped["featureLabel"] == first["featureLabel"]
+
+    def test_a_chosen_face_can_still_be_measured_to(self, mortise_and_tenon_frame):
+        # The point of reaching it.
+        state, slot, payload, _first = self._at_an_edge(
+            mortise_and_tenon_frame, "receiving_timber")
+
+        second = runner._handle_find_csg_at_point(
+            state, dict(payload, candidateIndex=1), slot)
+
+        assert runner.resolve_anchor(mortise_and_tenon_frame, second["reference"]) is not None


### PR DESCRIPTION
Rebased onto main after the parts that were **not** about picking were pulled out into #15 — the identity ordering fix, `add_measurement` and the two-tier merge it needed, and two small refactors. What is left here is selection and how it behaves.

## How it behaves

Inside a drawing, clicking a feature starts or continues a measurement rather than selecting it — there is no plain "look at this one" in a drawing.

| state | click | escape |
|---|---|---|
| nothing held | first feature held | — |
| one held | measurement made | release it, leave the mode |
| two held | replaces the second | release the second, keep the first |

Leaving a half-made measurement takes two presses, and a misclick on the second end is corrected by clicking the right one rather than starting over. Changing scene clears the mode, the hover and the focus: a feature selected in the model means nothing in a drawing, and either left lit would be something the new mode cannot act on.

## The second pick decides the viewport

A dimension is a projection, so it belongs to one view. Making it the second means the first can come from whichever view shows that feature best, and the dimension is drawn where the pair was completed. Re-picking the second end moves it.

## Red means the click will be refused

While one end is held, a feature that cannot finish the measurement is drawn red and refused, with the reason in the output:

- **not measurable in this view** — two faces at an angle are an angle in one view and cover each other in another, so the useful thing is to see that and move
- **the measurement would be zero** — two things in line are a good pair whose distance is nothing, and a dimension reading zero says nothing while covering what it is drawn over
- **nothing to measure against** — no plane or line of its own, or a face nobody declared, so a dimension to it could not be saved

The hover and the click go through **one verdict**. Two would eventually disagree, and a feature drawn red that the click then accepted would be worse than either alone.

That last case matters more than it sounds: 13% of the surface of a beam in tinyhouse120 resolves to unnamed joint geometry. Taken as a first pick it is a dead end — every second pick is then refused for a reason about the pick you just made rather than the one from a minute ago, which reads as the click doing nothing.

## Tab reaches what ranking hides

A face seen edge-on shows as a line, and on that line the edge formed with it wins — an edge is the more specific answer. So such a face was never the best answer *anywhere on the model*, and could not be selected at all. It is also the one most worth measuring to in an elevation.

Nothing was missing from the machinery: a click at an arris already offers the edge and both faces. Tab steps through them and the hover redraws, so choosing happens by looking.

## The held feature is drawn

In its own colour — neither hovered nor selected, held. As mesh **and** edges, because a face seen exactly edge-on projects to a line with no area, so the mesh alone renders as nothing while its boundary still projects to that line.

## Tolerances

Edge `2 → 4 mm`, point `4 → 8 mm`. They are what a measurement is usually taken to — a dimension runs to an arris or a corner far more often than to the middle of a face — and a snap that keeps missing is worse than one that occasionally takes the neighbouring edge, which the specificity ordering then sorts out.

## Not in this PR

Editing a measurement (kind, placement) and deleting one. Both have a settled shape: a kind change is *suppress plus add*, since kind is part of identity, and delete is a `suppressed` entry.

## Tests

`1419` pytest, `590` jest, extension `13/13`.