### PR TITLE
Order identities across shapes, and let the file hold a measurement

### DIFF
--- a/kigumi/runner.py
+++ b/kigumi/runner.py
@@ -1654,10 +1654,12 @@ def _feature_path_identity(anchor: Any) -> Tuple[str, Tuple[str, ...], str, str]
 
 def _measure_pair_identity(measure: Dict[str, Any]) -> Tuple[Any, Any]:
     """Just the two features of a measurement, without what is measured between."""
+    from kumiki.identity import identity_order
+
     return tuple(sorted((
         _feature_path_identity(measure.get("a")),
         _feature_path_identity(measure.get("b")),
-    )))
+    ), key=identity_order))
 
 
 def _measure_identity(measure: Dict[str, Any]) -> Tuple[Any, Any, str]:
@@ -1677,10 +1679,12 @@ def _measure_identity(measure: Dict[str, Any]) -> Tuple[Any, Any, str]:
     """
     from kumiki.drawing import Measure, MeasurementKind
 
+    from kumiki.identity import identity_order
+
     first, second = sorted((
         _feature_path_identity(measure.get("a")),
         _feature_path_identity(measure.get("b")),
-    ))
+    ), key=identity_order)
     kind = measure.get("kind")
     return (
         first, second,
@@ -1920,6 +1924,82 @@ def _drawing_from_code(frame: Any, declared: Any) -> Dict[str, Any]:
     return scene
 
 
+def add_measurement(
+    frame: Any,
+    example_path: Optional[Path],
+    pending: List[Dict[str, Any]],
+    drawing_id: str,
+    viewport_id: str,
+    measure: Dict[str, Any],
+) -> Dict[str, Any]:
+    """Put a measurement on a viewport, and say which entry now holds it.
+
+    The file is where a measurement made in the viewer lives, even when the
+    drawing it is on came from code: an override contributes measurements to a
+    drawing the code still lays out. So this finds or makes that override rather
+    than touching the code drawing, which it could not change anyway.
+
+    A pair already measured in this viewport is replaced rather than added
+    beside. Two dimensions between the same two features, drawn on top of each
+    other, is not something anyone means to ask for -- and the second click of a
+    measurement is often a correction of the first.
+    """
+    existing = collect_drawings(frame, example_path, pending)
+    target = next((d for d in existing if d["id"] == drawing_id), None)
+    if target is None:
+        raise ValueError(f"No drawing {drawing_id!r} to measure on")
+
+    holder = _measurement_holder(existing, pending, target)
+    viewport = next(
+        (v for v in holder.setdefault("viewports", []) if v.get("id") == viewport_id), None)
+    if viewport is None:
+        viewport = {"id": viewport_id, "measurements": []}
+        holder["viewports"].append(viewport)
+
+    measures = viewport.setdefault("measurements", [])
+    pair = _measure_pair_identity(measure)
+    kept = [m for m in measures if _measure_pair_identity(m) != pair]
+    kept.append(measure)
+    viewport["measurements"] = kept
+
+    if holder not in pending:
+        pending.append(holder)
+    return holder
+
+
+def _measurement_holder(
+    existing: List[Dict[str, Any]],
+    pending: List[Dict[str, Any]],
+    target: Dict[str, Any],
+) -> Dict[str, Any]:
+    """The file entry a measurement on *target* belongs in, made if need be.
+
+    A drawing of the file's own holds its own measurements. One from the code
+    cannot, so it gets an override -- named after the drawing it overrides, so
+    that deleting the code drawing leaves something plainly dangling rather than
+    something that has quietly become a drawing in its own right.
+    """
+    if target.get("origin") == ORIGIN_FILE:
+        held = next((d for d in pending if d["id"] == target["id"]), None)
+        return held if held is not None else _savable_drawing(target)
+
+    overriding = target.get("overriddenBy")
+    if overriding:
+        held = next((d for d in pending if d["id"] == overriding), None)
+        if held is not None:
+            return held
+        found = next((d for d in existing if d["id"] == overriding), None)
+        if found is not None:
+            return _savable_drawing(found)
+
+    return {
+        "id": f"{target['id']}-measurements",
+        "name": target.get("name", target["id"]),
+        OVERRIDES_KEY: target["id"],
+        "viewports": [],
+    }
+
+
 def collect_drawings(
     frame: Any,
     example_path: Optional[Path],
@@ -1937,7 +2017,17 @@ def collect_drawings(
     `dirty` says a drawing is not in the file yet. It is worked out here rather
     than left for the viewer to infer, so there is one answer to it.
     """
-    from_file = _read_drawings_file(_drawings_file_path(example_path)) if example_path else []
+    saved = _read_drawings_file(_drawings_file_path(example_path)) if example_path else []
+    # Unsaved entries stand in for saved ones of the same id, and are merged in
+    # here rather than appended at the end. An override contributes measurements
+    # to a drawing the code lays out, so a pending override has to go through
+    # the same merge -- appended, it would replace the code drawing instead and
+    # take the layout with it.
+    pending_by_id = {entry["id"]: dict(entry) for entry in (pending or []) if entry.get("id")}
+    from_file = [pending_by_id.pop(entry["id"], entry) for entry in saved]
+    from_file.extend(pending_by_id.values())
+    unsaved = {entry["id"] for entry in (pending or []) if entry.get("id")}
+
     overrides = {
         entry[OVERRIDES_KEY]: entry for entry in from_file
         if isinstance(entry.get(OVERRIDES_KEY), str)
@@ -1977,20 +2067,14 @@ def collect_drawings(
         _attach_measurements(scene, _measurements_by_viewport(None, entry), scene["name"])
         drawings.append(scene)
 
+    # Not in the file yet: either the drawing itself is unsaved, or the override
+    # contributing its measurements is. The second matters as much as the first
+    # -- a dimension added to a code drawing is unsaved work in a drawing that
+    # otherwise is not.
     for drawing in drawings:
-        drawing["dirty"] = False
-
-    # Made this session and not saved. A pending drawing that shares an id with
-    # a saved one has been made since, so it wins -- it is the newer answer.
-    for scene in (pending or []):
-        entry = dict(scene)
-        entry["dirty"] = True
-        entry.setdefault("origin", ORIGIN_FILE)
-        replaced = next((d for d in drawings if d["id"] == entry["id"]), None)
-        if replaced is None:
-            drawings.append(entry)
-        else:
-            drawings[drawings.index(replaced)] = entry
+        drawing["dirty"] = (
+            drawing["id"] in unsaved or drawing.get("overriddenBy") in unsaved
+        )
 
     return drawings
 
@@ -3068,7 +3152,7 @@ def make_ready_event(state: RunnerState) -> Dict[str, Any]:
             "get_layers_tree", "get_csg_tree",
             "get_default_drawing_for_debugging",
             "create_drawing_from_selection",
-            "get_drawings", "save_drawings",
+            "get_drawings", "save_drawings", "add_measurement",
             "load_slot", "unload_slot", "list_slots",
             "list_available_patterns", "raise_specific_pattern",
             "shutdown",
@@ -4612,6 +4696,23 @@ def handle_request(state: RunnerState, request: Dict[str, Any]) -> tuple[RunnerS
         ss.pending_drawings = []
         return state, make_success_response(request_id, command, {
             "path": written,
+            "scenes": collect_drawings(ss.frame, ss.file_path, ss.pending_drawings),
+        }), False
+
+    if command == "add_measurement":
+        ss = _resolve_slot(state, payload)
+        add_measurement(
+            ss.frame, ss.file_path, ss.pending_drawings,
+            str(payload.get("drawingId") or ""),
+            str(payload.get("viewportId") or ""),
+            {
+                "a": payload.get("a"),
+                "b": payload.get("b"),
+                "kind": payload.get("kind"),
+                "measureId": payload.get("measureId"),
+            },
+        )
+        return state, make_success_response(request_id, command, {
             "scenes": collect_drawings(ss.frame, ss.file_path, ss.pending_drawings),
         }), False
 

--- a/kigumi/webview/selection-store.js
+++ b/kigumi/webview/selection-store.js
@@ -129,6 +129,12 @@
             this.emit({ type: 'csg-focus', csgFocus: this.csgFocus });
         }
 
+        /**
+         * Stop looking at whatever is focused -- a feature OR a measurement.
+         *
+         * One field holds both, so this clears either. The name is about the
+         * common case rather than the whole of what it does.
+         */
         clearCsgFocus(options = {}) {
             if (!this.focus) {
                 return;

--- a/kigumi/webview/viewer-app.js
+++ b/kigumi/webview/viewer-app.js
@@ -5500,13 +5500,24 @@ class KigumiViewerApp extends LitElement {
         };
     }
 
-    _drawMeasurement(overlay, viewport, pageRect, measure) {
-        const camera = viewport.spec.camera || {};
-        const axes = {
+    /**
+     * A viewport's camera axes, as the measurement code wants them.
+     *
+     * In one place because three callers ask -- drawing a dimension, listing
+     * one, and now colouring a hover -- and a dimension that is drawn against
+     * different axes than it was judged against would be drawn wrong.
+     */
+    viewportAxes(viewport) {
+        const camera = (viewport && viewport.spec && viewport.spec.camera) || {};
+        return {
             look: camera.look || [0, 0, -1],
             right: camera.right || [1, 0, 0],
             up: camera.up || [0, 1, 0],
         };
+    }
+
+    _drawMeasurement(overlay, viewport, pageRect, measure) {
+        const axes = this.viewportAxes(viewport);
         // The same answer the list shows, so a dimension that is not drawn and
         // a row that says why can never disagree.
         const status = KigumiMeasurements.measurementStatus(measure, axes);
@@ -5848,12 +5859,7 @@ class KigumiViewerApp extends LitElement {
 
     /** One viewport's measurements, judged and described for the list. */
     _measurementRows(viewport) {
-        const camera = viewport.spec.camera || {};
-        const axes = {
-            look: camera.look || [0, 0, -1],
-            right: camera.right || [1, 0, 0],
-            up: camera.up || [0, 1, 0],
-        };
+        const axes = this.viewportAxes(viewport);
         return {
             id: viewport.id,
             measurements: (viewport.spec.measurements || []).map((measure) => {

--- a/kumiki/drawing.py
+++ b/kumiki/drawing.py
@@ -17,7 +17,8 @@ from dataclasses import dataclass, field, replace
 from enum import Enum
 from typing import Mapping, Optional, Tuple
 
-from .identity import DrawingId, FeaturePath, MeasurementId, TimberPath
+from .identity import (DrawingId, FeaturePath, MeasurementId, TimberPath,
+                       identity_order)
 
 
 class MeasurementSpace(Enum):
@@ -340,7 +341,7 @@ class Measure:
         if self.anchor_a is None or self.anchor_b is None:
             return
         first, second = self.anchor_a, self.anchor_b
-        if first.identity() <= second.identity():
+        if identity_order(first.identity()) <= identity_order(second.identity()):
             return
         object.__setattr__(self, 'anchor_a', second)
         object.__setattr__(self, 'anchor_b', first)

--- a/kumiki/identity.py
+++ b/kumiki/identity.py
@@ -165,6 +165,21 @@ class ResolvedJointPath:
         return cls(path=str(text))
 
 
+def identity_order(identity: Tuple) -> str:
+    """A sortable key for any identity tuple, whatever shape it is.
+
+    Identities are compared to put a pair in one order, and the shapes differ:
+    a face's third element is a feature's name, a derived edge's is a whole
+    parent reference. Python will not order a string against a tuple, so a pair
+    made of one of each -- a dimension from a face to an edge, which is an
+    ordinary thing to want -- raised instead of sorting.
+
+    The key only has to be total and stable, not meaningful: nothing reads the
+    order, it exists so that A to B and B to A come out the same way round.
+    """
+    return repr(identity)
+
+
 @dataclass(frozen=True)
 class FeatureRef:
     """Where a feature is within one timber's CSG, without saying which timber.

--- a/tests/test_kigumi_drawings_file.py
+++ b/tests/test_kigumi_drawings_file.py
@@ -917,3 +917,160 @@ class TestDerivedFeaturePath:
 
         assert isinstance(read, SingleFeaturePath)
         assert read.identity() == ("posts/fl#0", ("cut",), "x", "FACE")
+
+
+class TestAddingAMeasurement:
+    """Putting a measurement on a viewport, from the viewer."""
+
+    def _frame(self):
+        # No timbers: nothing here resolves an anchor, and a drawing is all the
+        # measurement needs somewhere to live.
+        return Frame(cut_timbers=[], name="f",
+                     drawings=[Drawing(name="plan", timber_paths=(TimberPath("post"),))])
+
+    def _measure(self):
+        return {
+            "a": {"timber": "post#0", "csgPath": ["cut"], "feature": "left", "type": "FACE"},
+            "b": {"timber": "post#0", "csgPath": ["cut"], "feature": "right", "type": "FACE"},
+            "kind": None,
+            "measureId": None,
+        }
+
+    def test_a_code_drawing_gets_an_override_to_hold_it(self):
+        # The code drawing cannot hold it -- it is code -- so the file does,
+        # while the code keeps the layout.
+        runner = _load_runner()
+        frame = self._frame()
+        pending = []
+
+        holder = runner.add_measurement(frame, None, pending, "plan", "front", self._measure())
+
+        assert holder[runner.OVERRIDES_KEY] == "plan"
+        assert holder in pending
+        assert holder["viewports"][0]["id"] == "front"
+        assert len(holder["viewports"][0]["measurements"]) == 1
+
+    def test_the_drawing_still_shows_as_the_codes_own_layout(self):
+        runner = _load_runner()
+        frame = self._frame()
+        pending = []
+        runner.add_measurement(frame, None, pending, "plan", "front", self._measure())
+
+        scenes = runner.collect_drawings(frame, None, pending)
+        plan = next(d for d in scenes if d["id"] == "plan")
+
+        assert plan["origin"] == runner.ORIGIN_OVERRIDDEN
+        assert plan["dirty"] is True
+
+    def test_a_second_measurement_of_the_same_pair_replaces_the_first(self):
+        # Two dimensions between one pair drawn on top of each other is not
+        # something anyone means to ask for.
+        runner = _load_runner()
+        frame = self._frame()
+        pending = []
+        runner.add_measurement(frame, None, pending, "plan", "front", self._measure())
+
+        second = dict(self._measure(), kind="horizontal")
+        holder = runner.add_measurement(frame, None, pending, "plan", "front", second)
+
+        measures = holder["viewports"][0]["measurements"]
+        assert len(measures) == 1
+        assert measures[0]["kind"] == "horizontal"
+
+    def test_a_different_pair_sits_beside_it(self):
+        runner = _load_runner()
+        frame = self._frame()
+        pending = []
+        runner.add_measurement(frame, None, pending, "plan", "front", self._measure())
+
+        other = dict(self._measure())
+        other["b"] = dict(other["b"], feature="top")
+        holder = runner.add_measurement(frame, None, pending, "plan", "front", other)
+
+        assert len(holder["viewports"][0]["measurements"]) == 2
+
+    def test_another_viewport_is_another_place(self):
+        # A measurement lives in the viewport it is drawn in; the same pair in
+        # the plan is a different dimension with a different number.
+        runner = _load_runner()
+        frame = self._frame()
+        pending = []
+        runner.add_measurement(frame, None, pending, "plan", "front", self._measure())
+
+        holder = runner.add_measurement(frame, None, pending, "plan", "top", self._measure())
+
+        assert {v["id"] for v in holder["viewports"]} == {"front", "top"}
+
+    def test_measuring_on_a_drawing_that_is_not_there(self):
+        runner = _load_runner()
+
+        with pytest.raises(ValueError, match="No drawing"):
+            runner.add_measurement(self._frame(), None, [], "nope", "front", self._measure())
+
+
+class TestAMeasurementMadeInTheViewer:
+    """The whole way from a pick to a dimension on the sheet."""
+
+    def _fixture_frame(self):
+        import importlib.util
+        import sys
+
+        path = (Path(__file__).resolve().parent.parent
+                / "kigumi" / "test-fixtures" / "measured_frame.py")
+        spec = importlib.util.spec_from_file_location("kigumi_measured_fixture", path)
+        module = importlib.util.module_from_spec(spec)
+        sys.modules["kigumi_measured_fixture"] = module
+        spec.loader.exec_module(module)
+        return module.build_frame()
+
+    def _anchor(self, cut, feature):
+        return {"timber": "butt_timber#0", "csgPath": list(cut),
+                "feature": feature, "type": "FACE"}
+
+    def test_it_lands_on_the_drawing_the_code_laid_out(self):
+        runner = _load_runner()
+        frame = self._fixture_frame()
+        scenes = runner.collect_drawings(frame, None, [])
+        drawing = next(d for d in scenes if d["viewports"])
+        viewport = drawing["viewports"][0]["id"]
+        pending = []
+
+        runner.add_measurement(frame, None, pending, drawing["id"], viewport, {
+            "a": self._anchor(("tenon_waste", "tenon"), "tenon_top"),
+            "b": self._anchor(("tenon_waste", "shoulder"), "shoulder"),
+            "kind": None, "measureId": None,
+        })
+
+        after = next(d for d in runner.collect_drawings(frame, None, pending)
+                     if d["id"] == drawing["id"])
+        drawn = [m for v in after["viewports"] for m in (v.get("measurements") or [])]
+
+        assert len(drawn) >= 1
+        # The layout is still the code's, and the measurement is the file's.
+        assert len(after["viewports"]) == len(drawing["viewports"])
+        assert after["origin"] == runner.ORIGIN_OVERRIDDEN
+        assert after["dirty"] is True
+
+    def test_both_ends_resolve_to_somewhere(self):
+        # A measurement that cannot find its features is shown as broken, so
+        # this is the difference between a dimension and a complaint.
+        runner = _load_runner()
+        frame = self._fixture_frame()
+        scenes = runner.collect_drawings(frame, None, [])
+        drawing = next(d for d in scenes if d["viewports"])
+        pending = []
+
+        runner.add_measurement(frame, None, pending, drawing["id"],
+                               drawing["viewports"][0]["id"], {
+            "a": self._anchor(("tenon_waste", "tenon"), "tenon_top"),
+            "b": self._anchor(("tenon_waste", "shoulder"), "shoulder"),
+            "kind": None, "measureId": None,
+        })
+
+        after = next(d for d in runner.collect_drawings(frame, None, pending)
+                     if d["id"] == drawing["id"])
+        made = next(m for v in after["viewports"] for m in (v.get("measurements") or [])
+                    if m["a"].get("feature") == "tenon_top")
+
+        assert made["a"].get("at") is not None
+        assert made["b"].get("at") is not None

--- a/tests/test_measurement_kinds.py
+++ b/tests/test_measurement_kinds.py
@@ -25,7 +25,8 @@ from kumiki.drawing import (
     does_override,
     kinds_for,
 )
-from kumiki.identity import FeatureRef, ResolvedTimberPath, SingleFeaturePath
+from kumiki.identity import (DerivedFeaturePath, FeatureRef, ResolvedTimberPath,
+                             SingleFeaturePath)
 
 DISTANCE = MeasurementOperation.DISTANCE
 ANGLE = MeasurementOperation.ANGLE
@@ -322,3 +323,37 @@ class TestWhatReplacesWhat:
         assert not does_override(measure, measure, self.CODED, self.FILE)
         assert not does_override(measure, measure, self.GENERATED, self.FILE)
         assert not does_override(measure, measure, self.GENERATED, self.CODED)
+
+
+class TestMeasuringAFaceToAnEdge:
+    """The pair whose two identities are different shapes."""
+
+    def _face(self):
+        return SingleFeaturePath(
+            ResolvedTimberPath("post"), FeatureRef(("cut",), "tenon_left"), "FACE")
+
+    def _edge(self):
+        return DerivedFeaturePath(
+            ResolvedTimberPath("post"),
+            FeatureRef(("cut",), "tenon_left"), FeatureRef(("body",), "rough.front"))
+
+    def test_it_can_be_measured_at_all(self):
+        # A face's identity has a name where an edge's has a whole parent
+        # reference, and python will not order a string against a tuple. So
+        # this raised rather than measuring -- on the ordinary case of
+        # dimensioning a face to an arris.
+        measure = Measure(self._face(), self._edge())
+
+        assert measure.identity() is not None
+
+    def test_it_is_one_measurement_whichever_way_round(self):
+        assert Measure(self._face(), self._edge()).identity() == Measure(
+            self._edge(), self._face()).identity()
+
+    def test_the_order_is_stable(self):
+        # Nothing reads the order; it exists so a pair comes out the same way
+        # round every time.
+        one = Measure(self._face(), self._edge())
+        other = Measure(self._face(), self._edge())
+
+        assert one.anchor_a.identity() == other.anchor_a.identity()


### PR DESCRIPTION
Pulled out of the measurement-picking branch, because none of it is about picking. Each piece stands alone.

## A face could not be measured to an edge

```
face identity: ('t#0', ('cut',), 'tenon_left', 'FACE')
edge identity: ('t#0', (('body',), 'b'), (('cut',), 'a'), 'EDGE')
'<' not supported between instances of 'tuple' and 'str'
```

A face's identity holds a feature's *name* in slot 2; a derived edge's holds a whole *parent reference*. Python will not order a string against a tuple, so the pair that raised was a face and an edge — an ordinary dimension, from a cheek to an arris — and it would have raised just as readily for one written in code.

`identity_order` is total across both shapes. Nothing reads the order; it exists so that A→B and B→A come out the same way round.

## The file can hold a measurement

`add_measurement` puts one on a viewport. A drawing from code cannot hold a measurement, so it gets an **override** that does, while the code keeps the layout. A pair already measured in that viewport is replaced rather than drawn on top of itself.

## Which needed the two-tier merge fixed

Pending entries now go through the **same override merge** as saved ones, instead of being appended at the end. Appended, a pending override replaced the code drawing outright and took its viewports with it.

A drawing whose *override* is unsaved now reads as `dirty` — it is, and that was previously only true of a drawing unsaved in its own right.

## Two smaller things

- `viewportAxes` is one function rather than three copies of the same six lines. A dimension drawn against different axes than it was judged against would be drawn wrong.
- `clearCsgFocus` says in its docstring that it clears a measurement focus too. One field holds both, and the name is about the common case rather than the whole of what it does — worth writing where someone reaching for a `clearMeasurementFocus` that does not exist will look.

## Tests

`1414` pytest, `576` jest, extension `13/13`.